### PR TITLE
Add back to top button to all pages & disable TOC on right

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -12,6 +12,7 @@ pygmentsStyle = "monokai"
 disableReadmoreNav = true
 menushortcutsnewtab = true
 site_logo = "/Azure-Proactive-Resiliency-Library/media/img/aprl-white.png"
+toc = false
 
 [markup]
   [markup.goldmark]

--- a/docs/themes/ace-documentation/layouts/_default/baseof.html
+++ b/docs/themes/ace-documentation/layouts/_default/baseof.html
@@ -1,43 +1,54 @@
 <!DOCTYPE html>
 <html>
-    {{- partial "head.html" . -}}
-    <body>
+{{- partial "head.html" . -}}
 
-        {{- partial "header.html" . -}}
+<body>
 
-        <div class="container-fluid">
-            <div class="row">
+  <script src="https://unpkg.com/vanilla-back-to-top@7.2.1/dist/vanilla-back-to-top.min.js"></script>
+  <script>addBackToTop({
+      diameter: 75,
+      backgroundColor: 'rgb(0, 123, 255)',
+      textColor: '#ffffff',
+      cornerOffset: 25,
+      scrollDuration: 300
+    })</script>
 
-                <div class="docs-sidenav order-0 col-12 col-md-3 col-lg-2 col-xl-2 position-sticky border-right">
-                    {{- partial "menu.html" . -}}
-                </div>
+  {{- partial "header.html" . -}}
 
-                {{- if and (ne .Site.Params.toc false) (ne .Params.toc false) }}
-                <div class="docs-toc large order-lg-2 order-md-0 order-xs-1 col-12 col-lg-2 col-xl-2 position-sticky border-left">
-                    {{- partial "tableofcontents.html" . -}}
-                </div>
-                <div class="main col-12 order-1 col-md-9 col-lg-10 col-xl-8 py-3">
-                {{else}}
-                <div class="main col-12 order-1 col-md-9 col-lg-10 col-xl-10 py-3">
-                {{end}}
+  <div class="container-fluid">
+    <div class="row">
 
-                    {{- block "main" . }}{{- end }}
-                    
-                    <div class="row">
-                        {{- if and (ne .Site.Params.disableReadmoreNav true) (ne .Params.disableReadmoreNav true) -}}
-                        <div class="position-relative mx-auto col-lg-9">
-                          {{ partial "next-prev-page.html" . }}
-                        </div>
-                        {{- end -}}
-                    </div> <!-- /end of row -->
+      <div class="docs-sidenav order-0 col-12 col-md-3 col-lg-2 col-xl-2 position-sticky border-right">
+        {{- partial "menu.html" . -}}
+      </div>
 
-                </div>
+      {{- if and (ne .Site.Params.toc false) (ne .Params.toc false) }}
+      <div class="docs-toc large order-lg-2 order-md-0 order-xs-1 col-12 col-lg-2 col-xl-2 position-sticky border-left">
+        {{- partial "tableofcontents.html" . -}}
+      </div>
+      <div class="main col-12 order-1 col-md-9 col-lg-10 col-xl-8 py-3">
+        {{else}}
+        <div class="main col-12 order-1 col-md-9 col-lg-10 col-xl-10 py-3">
+          {{end}}
 
-            </div> <!-- /end of row -->
+          {{- block "main" . }}{{- end }}
 
-        </div> <!-- /end of container -->
+          <div class="row">
+            {{- if and (ne .Site.Params.disableReadmoreNav true) (ne .Params.disableReadmoreNav true) -}}
+            <div class="position-relative mx-auto col-lg-9">
+              {{ partial "next-prev-page.html" . }}
+            </div>
+            {{- end -}}
+          </div> <!-- /end of row -->
 
-        {{- partial "footer.html" . -}}
+        </div>
 
-    </body>
+      </div> <!-- /end of row -->
+
+    </div> <!-- /end of container -->
+
+    {{- partial "footer.html" . -}}
+
+</body>
+
 </html>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

As suggested in #8 this PR adds a back to top button to all pages without requiring any contributor to add code to their `.md` file via the power of hugo 😎 and also disables the TOC on right

![image](https://user-images.githubusercontent.com/41163455/229160558-ce67baa2-f274-4366-b354-ebb81969334a.png)

![image](https://user-images.githubusercontent.com/41163455/229165004-fee59166-3433-4f7b-8463-0869b33e1c0e.png)


## This PR fixes/adds/changes/removes

1. Add back to top button to all pages
2. Disable TOC on right

### Breaking Changes

None

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
