### PR TITLE
Revert back to prioritize content weight

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -13,7 +13,6 @@ disableReadmoreNav = true
 menushortcutsnewtab = true
 site_logo = "/Azure-Proactive-Resiliency-Library/media/img/aprl-white.png"
 toc = false
-ordersectionsby = "title"
 
 [markup]
   [markup.goldmark]


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

With the addition of the WAF category, I am reverting back to priortize sort by weight instead of the title. 

![image](https://github.com/Azure/Azure-Proactive-Resiliency-Library/assets/30884663/2b05b158-cfb9-48f3-b967-90408f2124a2)


## This PR fixes/adds/changes/removes

1. Revert previous change to prioritize content sorting by title.
### Breaking Changes

None

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
