### PR TITLE
Attempt to get Traffic manager and app gateway queries to display again

### DIFF
--- a/docs/content/services/networking/application-gateway/_index.md
+++ b/docs/content/services/networking/application-gateway/_index.md
@@ -48,7 +48,7 @@ Definitions of states can be found [here]({{< ref "../../../_index.md#definition
 **Resource Graph Query/Scripts**
 
 {{< collapse title="Show/Hide Query/Script" >}}
-{{< code lang="sql" file="code/AGW-1/AGW-1.kql" >}} {{< /code >}}
+{{< code lang="sql" file="code/agw-1/agw-1.kql" >}} {{< /code >}}
 {{< /collapse >}}
 <br><br>
 
@@ -72,7 +72,7 @@ Ensure that all incoming connections are using HTTP/s for production services.  
 
 {{< collapse title="Show/Hide Query/Script" >}}
 
-{{< code lang="sql" file="code/AGW-2/AGW-2.kql" >}} {{< /code >}}
+{{< code lang="sql" file="code/agw-2/agw-2.kql" >}} {{< /code >}}
 
 {{< /collapse >}}
 
@@ -95,7 +95,7 @@ Use Application Gateway with Web Application Firewall (WAF) within an applicatio
 
 {{< collapse title="Show/Hide Query/Script" >}}
 
-{{< code lang="sql" file="code/AGW-3/AGW-3.kql" >}} {{< /code >}}
+{{< code lang="sql" file="code/agw-3/agw-3.kql" >}} {{< /code >}}
 
 {{< /collapse >}}
 
@@ -119,7 +119,7 @@ You should use Application Gateway v2 unless there is a compelling reason for us
 
 {{< collapse title="Show/Hide Query/Script" >}}
 
-{{< code lang="sql" file="code/AGW-4/AGW-4.kql" >}} {{< /code >}}
+{{< code lang="sql" file="code/agw-4/agw-4.kql" >}} {{< /code >}}
 
 {{< /collapse >}}
 
@@ -142,7 +142,7 @@ Enable logs that can be stored in storage accounts, Log Analytics, and other mon
 
 {{< collapse title="Show/Hide Query/Script" >}}
 
-{{< code lang="sql" file="code/AGW-5/AGW-5.kql" >}} {{< /code >}}
+{{< code lang="sql" file="code/agw-5/agw-5.kql" >}} {{< /code >}}
 
 {{< /collapse >}}
 
@@ -165,7 +165,7 @@ Using custom health probes can help with understand the availability of your bac
 
 {{< collapse title="Show/Hide Query/Script" >}}
 
-{{< code lang="sql" file="code/AGW-6/AGW-6.kql" >}} {{< /code >}}
+{{< code lang="sql" file="code/agw-6/agw-6.kql" >}} {{< /code >}}
 
 {{< /collapse >}}
 
@@ -188,7 +188,7 @@ Deploying your backend services in a zone-aware configurations ensures that if a
 
 {{< collapse title="Show/Hide Query/Script" >}}
 
-{{< code lang="sql" file="code/AGW-7/AGW-7.kql" >}} {{< /code >}}
+{{< code lang="sql" file="code/agw-7/agw-7.kql" >}} {{< /code >}}
 
 {{< /collapse >}}
 
@@ -211,7 +211,7 @@ Plan for backend maintenance by using connection draining. Connection draining h
 
 {{< collapse title="Show/Hide Query/Script" >}}
 
-{{< code lang="sql" file="code/AGW-8/AGW-8.kql" >}} {{< /code >}}
+{{< code lang="sql" file="code/agw-8/agw-8.kql" >}} {{< /code >}}
 
 {{< /collapse >}}
 

--- a/docs/content/services/networking/traffic-manager/_index.md
+++ b/docs/content/services/networking/traffic-manager/_index.md
@@ -1,10 +1,10 @@
 +++
 title = "Traffic Manager"
 description = "Best practices and resiliency recommendations for Azure Traffic Manager."
-date = "6/13/23"
+date = "9/21/23"
 author = "chinthakaru"
 msAuthor = "crupasinghe"
-draft = true
+draft = false
 +++
 
 The presented resiliency recommendations in this guidance include Azure Traffic Manager and associated settings.

--- a/docs/themes/ace-documentation/exampleSite/content/shortcodes/buttons.md
+++ b/docs/themes/ace-documentation/exampleSite/content/shortcodes/buttons.md
@@ -17,7 +17,7 @@ The button shortcode allows you to add a button to the page. This button is a HT
 ## Usage
 Place the following shortcode on the page
 {{< code lang="html" >}}
-{{</* button style="STYLE" link="https://yourwebsite.com" */>}} [content] {{</* /button */>}}
+{{</* button style="STYLE" link="https://azure.github.io/Azure-Proactive-Resiliency-Library/" */>}} [content] {{</*/button*/>}}
 {{< /code >}}
 
 ### Parameters


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Attempt to fix #88 

## This PR fixes/adds/changes/removes


Everything is still working locally:
![image](https://github.com/Azure/Azure-Proactive-Resiliency-Library/assets/30884663/ff700b21-e5f0-4b86-bb4a-2172c045b639)


1. Fixes issue with traffic manager and the agw queries not showing up in GitHub pages. 

### Breaking Changes

1. None

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
