### PR TITLE
Adds clarity for linking work items and issues to PR form

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@ Replace this with a brief description of what this Pull Request fixes, changes, 
 Replace this with a list of related GitHub Issues and/or ADO Work Items (Internal Only)
 
 - To associate a GitHub Issue, use a [key word](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) preceded with the GitHub issue number.
-- To associate an ADO Work Item, use the [ADO Work Item ID](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) preceded with `AB#`.
+- To associate an ADO Work Item, use the key word `AB#` succeeded with the [ADO Work Item ID](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
 
 ## This PR fixes/adds/changes/removes
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@ Replace this with a brief description of what this Pull Request fixes, changes, 
 Replace this with a list of related GitHub Issues and/or ADO Work Items (Internal Only)
 
 - To associate a GitHub Issue, use a [key word](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) preceded with the GitHub issue number.
-- To associate a ADO Work Item, use the [ADO Work Item ID](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) preceded with `AB#`.
+- To associate an ADO Work Item, use the [ADO Work Item ID](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) preceded with `AB#`.
 
 ## This PR fixes/adds/changes/removes
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,13 @@
 
 Replace this with a brief description of what this Pull Request fixes, changes, etc.
 
+## Related Issues/Work Items
+
+Replace this with a list of related GitHub Issues and/or ADO Work Items (Internal Only)
+
+- To associate a GitHub Issue, use a [key word](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) preceded with the GitHub issue number.
+- To associate a ADO Work Item, use the [ADO Work Item ID](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) preceded with `AB#`.
+
 ## This PR fixes/adds/changes/removes
 
 1. *Replace me*


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

[AB#31225](https://dev.azure.com/CSUSolEng/12ba7e46-a92a-47f6-ad6a-fba0479234a7/_workitems/edit/31225)
Currently a requirement in PR to link the work items and issues, but not clear where to include them or what keywords to use.

## This PR fixes/adds/changes/removes

1. Adds clarity for linking work items and issues to PR form

### Breaking Changes

1. None, just text changes to PR form.

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
