### PR TITLE
update vmss-5 ARG query

### DIFF
--- a/docs/content/services/compute/virtual-machine-scale-sets/code/vmss-5/vmss-5.kql
+++ b/docs/content/services/compute/virtual-machine-scale-sets/code/vmss-5/vmss-5.kql
@@ -9,6 +9,6 @@ resources
     | where tostring(properties.targetResourceUri) contains "Microsoft.Compute/virtualMachineScaleSets"
     | project id = tostring(properties.targetResourceUri), autoscalesettings = properties
 ) on id
-| where isnull(autoscalesettings) or autoscalesettings.enabled == "disabled" and autoscalesettings.predictiveAutoscalePolicy.scaleMode == "Disabled"
+| where autoscalesettings.enabled == "true" and autoscalesettings.predictiveAutoscalePolicy.scaleMode == "Disabled"
 | project recommendationId = "vmss-5", name, id, param1 = "predictiveAutoscalePolicy_scaleMode: Disabled"
 | order by id asc


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Minor update to VMSS-5 ARG query

## Related Issues/Work Items

[AB#31335](https://dev.azure.com/CSUSolEng/12ba7e46-a92a-47f6-ad6a-fba0479234a7/_workitems/edit/31335)

## This PR fixes/adds/changes/removes

1. update VMSS-5 ARG query to return VMSS instances with autoscale enabled and predictive autoscale disabled

### Breaking Changes

1. None

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
