### PR TITLE
feat: Added LB with Zone Redundancy

### DIFF
--- a/docs/content/services/networking/load-balancer/_index.md
+++ b/docs/content/services/networking/load-balancer/_index.md
@@ -1,7 +1,7 @@
 +++
 title = "Load Balancer"
 description = "Best practices and resiliency recommendations for Load Balancer and associated resources."
-date = "4/12/23"
+date = "10/19/23"
 author = "lachaves"
 msAuthor = "luchaves"
 draft = false
@@ -19,6 +19,7 @@ The below table shows the list of resiliency recommendations for Load Balancer a
 | [LB-1 - Use Standard Load Balancer SKU](#lb-1---use-standard-load-balancer-sku) | Preview  |         Yes         |
 | [LB-2 - Ensure the Backend Pool contains at least two instances](#lb-2---ensure-the-backend-pool-contains-at-least-two-instances) | Preview |         Yes          |
 | [LB-3 - Use NAT Gateway instead of Outbound Rules for Production Workloads](#lb-3---use-nat-gateway-instead-of-outbound-rules-for-production-workloads) | Preview |         Yes          |
+| [LB-4 - Ensure Standard Load Balancer is zone-redundant](#lb-4---ensure-standard-load-balancer-is-zone-redundant) | GA | Yes |
 {{< /table >}}
 
 {{< alert style="info" >}}
@@ -91,6 +92,28 @@ Outbound rules ensure that you are not faced with connection failures as a resul
 {{< collapse title="Show/Hide Query/Script" >}}
 
 {{< code lang="sql" file="code/lb-3/lb-3.kql" >}} {{< /code >}}
+
+{{< /collapse >}}
+
+<br><br>
+
+### LB-4 - Ensure Standard Load Balancer is zone-redundant
+
+**Impact: High**
+
+**Guidance**
+
+ In a region with Availability Zones, a Standard Load Balancer can be zone-redundant with traffic served by a single IP address. A single frontend IP address survives zone failure. The frontend IP may be used to reach all (non-impacted) backend pool members no matter the zone. Up to one availability zone can fail and the data path survives as long as the remaining zones in the region remain healthy.
+
+**Resources**
+
+- [Load Balancer and Availability Zones](https://learn.microsoft.com/en-us/azure/load-balancer/load-balancer-standard-availability-zones#zone-redundant)
+
+**Resource Graph Query/Scripts**
+
+{{< collapse title="Show/Hide Query/Script" >}}
+
+{{< code lang="sql" file="code/lb-4/lb-4.kql" >}} {{< /code >}}
 
 {{< /collapse >}}
 

--- a/docs/content/services/networking/load-balancer/code/lb-4/lb-4.kql
+++ b/docs/content/services/networking/load-balancer/code/lb-4/lb-4.kql
@@ -1,0 +1,19 @@
+// Azure Resource Graph Query
+// Find all LoadBalancers with with regional or zonal public IP Addresses
+resources
+| where type == "microsoft.network/loadbalancers"
+| where tolower(sku.name) != 'basic'
+| mv-expand feIPconfigs = properties.frontendIPConfigurations
+| extend
+    PIPid = toupper(feIPconfigs.properties.publicIPAddress.id),
+    JoinID = toupper(id)
+| join kind=leftouter (
+    resources
+    | where type == "microsoft.network/publicipaddresses"
+    | where isnull(zones) or array_length(zones) < 2
+    | extend
+        LBid = toupper(substring(properties.ipConfiguration.id, 0, indexof(properties.ipConfiguration.id, '/frontendIPConfigurations'))),
+        InnerID = toupper(id)
+) on $left.JoinID == $right.LBid
+| distinct name, name1, id, id1
+| project recommendationId = "lb-4", name, id, param1="Zones: No Zone or Zonal", param2=strcat("PIP id:", " ", id1)

--- a/docs/content/services/networking/load-balancer/code/lb-4/lb-4.kql
+++ b/docs/content/services/networking/load-balancer/code/lb-4/lb-4.kql
@@ -5,15 +5,29 @@ resources
 | where tolower(sku.name) != 'basic'
 | mv-expand feIPconfigs = properties.frontendIPConfigurations
 | extend
+    feConfigName = (feIPconfigs.name),
+    PrivateSubnetId = toupper(feIPconfigs.properties.subnet.id),
+    PrivateIPZones = feIPconfigs.zones,
     PIPid = toupper(feIPconfigs.properties.publicIPAddress.id),
     JoinID = toupper(id)
-| join kind=leftouter (
-    resources
-    | where type == "microsoft.network/publicipaddresses"
-    | where isnull(zones) or array_length(zones) < 2
+| where isnotempty(PrivateSubnetId)
+| where isnull(PrivateIPZones) or array_length(PrivateIPZones) < 2
+| project name, feConfigName, id
+| union (resources
+    | where type == "microsoft.network/loadbalancers"
+    | where tolower(sku.name) != 'basic'
+    | mv-expand feIPconfigs = properties.frontendIPConfigurations
     | extend
-        LBid = toupper(substring(properties.ipConfiguration.id, 0, indexof(properties.ipConfiguration.id, '/frontendIPConfigurations'))),
-        InnerID = toupper(id)
-) on $left.JoinID == $right.LBid
-| distinct name, name1, id, id1
-| project recommendationId = "lb-4", name, id, param1="Zones: No Zone or Zonal", param2=strcat("PIP id:", " ", id1)
+        feConfigName = (feIPconfigs.name),
+        PIPid = toupper(feIPconfigs.properties.publicIPAddress.id),
+        JoinID = toupper(id)
+    | where isnotempty(PIPid)
+    | join kind=innerunique (
+        resources
+        | where type == "microsoft.network/publicipaddresses"
+        | where isnull(zones) or array_length(zones) < 2
+        | extend
+            LBid = toupper(substring(properties.ipConfiguration.id, 0, indexof(properties.ipConfiguration.id, '/frontendIPConfigurations'))),
+            InnerID = toupper(id)
+    ) on $left.PIPid == $right.InnerID)
+| project recommendationId = "lb-4", name, id, param1="Zones: No Zone or Zonal", param2=strcat("Frontend IP Configuration:", " ", feConfigName)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Added LB-4 recommendation to identify all Standard Load Balancer(s) that are not zone-redundant.

## Related Issues/Work Items

[AB#29843](https://dev.azure.com/CSUSolEng/12ba7e46-a92a-47f6-ad6a-fba0479234a7/_workitems/edit/29843)

## This PR fixes/adds/changes/removes

1. Adds ARG query for finding Standard Load Balancer(s) without zone-redundancy

### Breaking Changes

N/A

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
