### PR TITLE
Fixed KQL bugs (31313, 31314, 31315)

### DIFF
--- a/docs/content/services/networking/front-door/_index.md
+++ b/docs/content/services/networking/front-door/_index.md
@@ -61,13 +61,6 @@ However, as part of a complex architecture, you might choose to use Traffic Mana
 - [Azure Traffic Manager](https://learn.microsoft.com/azure/traffic-manager/traffic-manager-overview)
 - [Azure Front Door](https://learn.microsoft.com/azure/frontdoor/front-door-overview)
 
-**Resource Graph Query/Scripts**
-
-{{< collapse title="Show/Hide Query/Script" >}}
-
-{{< code lang="sql" file="code/afd-1/afd-1.kql" >}} {{< /code >}}
-
-{{< /collapse >}}
 
 <br><br>
 

--- a/docs/content/services/networking/front-door/code/afd-1/afd-1.kql
+++ b/docs/content/services/networking/front-door/code/afd-1/afd-1.kql
@@ -1,3 +1,0 @@
-resources
-| where type == "microsoft.Network/trafficmanagerprofiles" or type == "microsoft.cdn/profiles"
-| project recommendationId = "afd-1", name, id

--- a/docs/content/services/networking/front-door/code/afd-10/afd-10.kql
+++ b/docs/content/services/networking/front-door/code/afd-10/afd-10.kql
@@ -1,4 +1,4 @@
 resources
-| where type == "microsoft.cdn/cdnwebapplicationfirewallpolicies"
+| where type == "microsoft.cdn/frontdoorwebapplicationfirewallpolicies"
 | where properties['policySettings']['enabledState'] == "Enabled"
 | project recommendationId = "afd-10", name, id

--- a/docs/content/services/networking/front-door/code/afd-11/afd-11.kql
+++ b/docs/content/services/networking/front-door/code/afd-11/afd-11.kql
@@ -1,4 +1,4 @@
 resources
 | where type == "microsoft.network/frontdoorwebapplicationfirewallpolicies"
-| where properties['managedRules']['managedRuleSets'][0]['ruleSetType'] == "Microsoft_DefaultRuleSet"
+| where properties['managedRules']['managedRuleSets'][0]['ruleSetType'] != "Microsoft_DefaultRuleSet"
 | project recommendationId = "afd-11", name, id


### PR DESCRIPTION
# Overview/Summary
Fixed the following bugs:
[AB#31313](https://dev.azure.com/CSUSolEng/12ba7e46-a92a-47f6-ad6a-fba0479234a7/_workitems/edit/31313) AFD-1 query should only return results if there is a mix of AFD and TM
[AB#31314](https://dev.azure.com/CSUSolEng/12ba7e46-a92a-47f6-ad6a-fba0479234a7/_workitems/edit/31314) AFD-10 Query is looking for incorrect type. Type should be: "microsoft.network/frontdoorwebapplicationfirewallpolicies"
[AB#31315](https://dev.azure.com/CSUSolEng/12ba7e46-a92a-47f6-ad6a-fba0479234a7/_workitems/edit/31315) AFD-11 - Query is returning WAFs that are configured correctly. Should return those that are not.


## Related Issues/Work Items

[AB#31313](https://dev.azure.com/CSUSolEng/12ba7e46-a92a-47f6-ad6a-fba0479234a7/_workitems/edit/31313) AFD-1 query should only return results if there is a mix of AFD and TM
[AB#31314](https://dev.azure.com/CSUSolEng/12ba7e46-a92a-47f6-ad6a-fba0479234a7/_workitems/edit/31314) AFD-10 Query is looking for incorrect type. Type should be: "microsoft.network/frontdoorwebapplicationfirewallpolicies"
[AB#31315](https://dev.azure.com/CSUSolEng/12ba7e46-a92a-47f6-ad6a-fba0479234a7/_workitems/edit/31315) AFD-11 - Query is returning WAFs that are configured correctly. Should return those that are not.

## This PR fixes/adds/changes/removes

1. KQL
2. Main markdown file. 

### Breaking Changes
NA

## As part of this Pull Request I have

- [x ] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing) and ensured this PR is compliant with the guide
- [ x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library/pulls)
- [x ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
- [ x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
- [ x] Ensured PR tests are passing
- [ x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
