### PR TITLE
APRL WAF updates and minor AGW update for Oct 2023

### DIFF
--- a/docs/content/services/networking/application-gateway/_index.md
+++ b/docs/content/services/networking/application-gateway/_index.md
@@ -12,17 +12,17 @@ The presented resiliency recommendations in this guidance include Application Ga
 ## Summary of Recommendations
 
 {{< table style="table-striped" >}}
-| Recommendation                                                                                                                              | Impact   | State    | ARG Query Available |
+| Recommendation | Impact | State | ARG Query Available |
 | :------------------------------------------------------------------------------------------------------------------------------------------ | :------: | :------: | :-----------------: |
-| [AGW-1 - Ensure autoscaling is used with a minimum of 2 instance](#agw-1---ensure-autoscaling-is-used-with-a-minimum-of-2-instance)     |  High    | Preview  | Yes |
-| [AGW-2 - Secure all incoming connections with SSL](#agw-2---secure-all-incoming-connections-with-ssl)                                   |  High    | Preview  | Yes |
-| [AGW-3 - Enable WAF policies](#agw-3---enable-web-application-firewall-policies)                                                        |  High    | Preview  | Yes |
-| [AGW-4 - Use Application GW V2 instead of V1](#agw-4---use-application-gw-v2-instead-of-v1)                                             |  High    | Preview  | Yes |
-| [AGW-5 - Monitor and Log the configurations and traffic](#agw-5---monitor-and-log-the-configurations-and-traffic)                       |  Medium  | Preview  | No |
-| [AGW-6 - Use Health Probes to detect backend availability](#agw-6---use-health-probes-to-detect-backend-availability)                   |  Medium  | Preview  | Yes |
-| [AGW-7 - Deploy backends in a zone-redundant configuration](#agw-7---deploy-backends-in-a-zone-redundant-configuration)                 |  High    | Preview  | No |
-| [AGW-8 - Plan for backend maintenance by using connection draining](#agw-8---plan-for-backend-maintenance-by-using-connection-draining) |  Medium  | Preview  | Yes |
-| [AGW-9 - Ensure Application Gateway Subnet is using a /24 subnet mask](#agw-9---ensure-application-gateway-subnet-is-using-a-24-subnet-mask)                       |  High    | Preview  | Yes |
+| [AGW-1 - Ensure autoscaling is used with a minimum of 2 instance](#agw-1---ensure-autoscaling-is-used-with-a-minimum-of-2-instance) | High | Preview | Yes |
+| [AGW-2 - Secure all incoming connections with SSL](#agw-2---secure-all-incoming-connections-with-ssl) | High | Preview | Yes |
+| [AGW-3 - Enable WAF policies](#agw-3---enable-web-application-firewall-policies) | High | Preview | Yes |
+| [AGW-4 - Use Application GW V2 instead of V1](#agw-4---use-application-gw-v2-instead-of-v1) | High | Preview | Yes |
+| [AGW-5 - Monitor and Log the configurations and traffic](#agw-5---monitor-and-log-the-configurations-and-traffic) | Medium | Preview | No |
+| [AGW-6 - Use Health Probes to detect backend availability](#agw-6---use-health-probes-to-detect-backend-availability) | Medium | Preview | Yes |
+| [AGW-7 - Deploy backends in a zone-redundant configuration](#agw-7---deploy-backends-in-a-zone-redundant-configuration) | High | Preview | No |
+| [AGW-8 - Plan for backend maintenance by using connection draining](#agw-8---plan-for-backend-maintenance-by-using-connection-draining) | Medium | Preview | Yes |
+| [AGW-9 - Ensure Application Gateway Subnet is using a /24 subnet mask](#agw-9---ensure-application-gateway-subnet-is-using-a-24-subnet-mask) | High | Preview | Yes |
 
 {{< /table >}}
 {{< alert style="info" >}}
@@ -41,7 +41,7 @@ Definitions of states can be found [here]({{< ref "../../../_index.md#definition
 
 **Guidance**
 
- When configuring the Application Gateway you should provision autoscaling and a minimum of two instances to minimize the effects of a single failing component. This allows for the opportunity to leverage the full capabilities of having a Layer 7 Load Balancing services. The creation of every new instance can take several minutes so having a minimum instance count of two ensure if one goes down for any reason that there is not a complete loss of connectivity to the backend services.  Auto scale allows the Application Gateway to scale out based on the traffic requirements without the need of manual intervention.
+When configuring the Application Gateway you should provision autoscaling and a minimum of two instances to minimize the effects of a single failing component. This allows for the opportunity to leverage the full capabilities of having a Layer 7 Load Balancing services. The creation of every new instance can take several minutes so having a minimum instance count of two ensure if one goes down for any reason that there is not a complete loss of connectivity to the backend services. Auto scale allows the Application Gateway to scale out based on the traffic requirements without the need of manual intervention.
 
 **Resources**
 
@@ -65,7 +65,7 @@ Definitions of states can be found [here]({{< ref "../../../_index.md#definition
 
 **Guidance**
 
-Ensure that all incoming connections are using HTTP/s for production services.  Using end to end SSL/TLS or SSL/TLS termination to ensure the security of all incoming connections to the Application Gateway allows you and your users to be safe from possible attacks as it ensures that all data passed between the web server and browsers remain private and encrypted.
+Ensure that all incoming connections are using HTTP/s for production services. Using end to end SSL/TLS or SSL/TLS termination to ensure the security of all incoming connections to the Application Gateway allows you and your users to be safe from possible attacks as it ensures that all data passed between the web server and browsers remain private and encrypted.
 
 **Resources**
 
@@ -118,7 +118,7 @@ Use Application Gateway with Web Application Firewall (WAF) within an applicatio
 
 **Guidance**
 
-You should use Application Gateway v2 unless there is a compelling reason for using v1. V2 has many more built in features such as autoscaling, static VIPs, Azure KeyVault integration for certificate management and many more features listed in our comparison charts.  Leveraging this updated version allows for better performance and control of how your traffic routed and the ability to make changes to the traffic.
+You should use Application Gateway v2 unless there is a compelling reason for using v1. V2 has many more built in features such as autoscaling, static VIPs, Azure KeyVault integration for certificate management and many more features listed in our comparison charts. Leveraging this updated version allows for better performance and control of how your traffic routed and the ability to make changes to the traffic.
 
 **Resources**
 
@@ -144,7 +144,7 @@ You should use Application Gateway v2 unless there is a compelling reason for us
 
 **Guidance**
 
-Enable logs that can be stored in storage accounts, Log Analytics, and other monitoring services.  If NSGs are applied NSG flow logs can be enabled and stored for traffic audit and to provide insights into the traffic flowing into your Azure Cloud.
+Enable logs that can be stored in storage accounts, Log Analytics, and other monitoring services. If NSGs are applied NSG flow logs can be enabled and stored for traffic audit and to provide insights into the traffic flowing into your Azure Cloud.
 
 **Resources**
 
@@ -250,6 +250,6 @@ Application Gateway (Standard_v2 or WAF_v2 SKU) can support up to 125 instances.
 **Resource Graph Query/Scripts**
 
 {{< collapse title="Show/Hide Query/Script" >}}
-{{< code lang="sql" file="code/agw-1/agw-9.kql" >}} {{< /code >}}
+{{< code lang="sql" file="code/agw-9/agw-9.kql" >}} {{< /code >}}
 {{< /collapse >}}
 <br><br>

--- a/docs/content/services/networking/web-application-firewall/_index.md
+++ b/docs/content/services/networking/web-application-firewall/_index.md
@@ -12,16 +12,13 @@ The presented resiliency recommendations in this guidance include Web Applicatio
 ## Summary of Recommendations
 
 {{< table style="table-striped" >}}
-| Recommendation                                                                                                                                                                                                                     | Impact |  State  | ARG Query Available |
+| Recommendation | Impact | State | ARG Query Available |
 | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :----: | :-----: | :-----------------: |
-| [WAF-1 - Associate Web Application Firewall policy with Azure Application Gateway](#waf-1---associate-web-application-firewall-policy-with-azure-application-gateway)                                                                                                                          |  High  | GA |         Yes         |
-| [WAF-2 - Associate Web Application Firewall with Azure Front Door](#waf-2---associate-web-application-firewall-with-azure-front-door)                                                                                                              |  High  | GA |         Yes         |
-| [WAF-3 - Review best practice for Web Application Firewall on Azure Application Gateway](#waf-3---review-best-practice-for-web-application-firewall-on-azure-application-gateway)                    |  Medium  | GA |         No         |
-| [WAF-4 - Review best practice for Web Application Firewall on Azure Front Door](#waf-4---review-best-practice-for-web-application-firewall-on-azure-front-door)                                                                                                        | Medium | GA |         No         |
-| [WAF-5 - Identify a blocked legitimate request for Web Application Firewall on Azure Front Door](#waf-5---identify-a-blocked-legitimate-request-for-web-application-firewall-on-azure-front-door)                                                                                                                |  High  | GA |         Yes         |
-| [WAF-6 - Identify a blocked legitimate request for Web Application Firewall on Azure Application Gateway](#waf-6---identify-a-blocked-legitimate-request-for-web-application-firewall-on-azure-application-gateway)                                                                                                                |  High  | GA |         Yes         |
-| [WAF-7 - Fixing a false positive for Web Application Firewall on Azure Application Gateway](#waf-7---fixing-a-false-positive-for-web-application-firewall-on-azure-application-gateway)                                                                                                                |  High  | GA |         No         |
-| [WAF-8 - Monitor Web Application Firewall](#waf-8---monitor-web-application-firewall)                                                                                                                |  Medium  | GA |         No         |
+| [WAF-1 - Review best practice for Web Application Firewall on Azure Application Gateway](#waf-1---review-best-practice-for-web-application-firewall-on-azure-application-gateway) | Medium | GA | No |
+| [WAF-2 - Review best practice for Web Application Firewall on Azure Front Door](#waf-2---review-best-practice-for-web-application-firewall-on-azure-front-door) | Medium | GA | No |
+| [WAF-3 - Review logs for Web Application Firewall on Azure Front Door for legitimate requests that are blocked](#waf-3---review-logs-for-web-application-firewall-on-azure-front-door-for-legitimate-requests-that-are-blocked) | High | GA | No |
+| [WAF-4 - Review logs for Web Application Firewall on Azure Application Gateway for legitimate requests that are blocked](#waf-4---review-logs-for-web-application-firewall-on-azure-application-gateway-for-legitimate-requests-that-are-blocked) | High | GA | No |
+| [WAF-5 - Monitor Web Application Firewall](#waf-5---monitor-web-application-firewall) | Medium | GA | No |
 {{< /table >}}
 
 {{< alert style="info" >}}
@@ -32,17 +29,17 @@ Definitions of states can be found [here]({{< ref "../../../_index.md#definition
 
 ## Recommendations Details
 
-### WAF-1 - Associate Web Application Firewall policy with Azure Application Gateway
+### WAF-1 - Review best practice for Web Application Firewall on Azure Application Gateway
 
-**Impact: High**
+**Impact: Medium**
 
 **Guidance**
 
-When you create a policy of WAF, it must be associated to an application gateway to take effect. Application Gateway has two versions of the WAF sku: Application Gateway WAF_v1 and Application Gateway WAF_v2. WAF policy associations are only supported for the Application Gateway WAF_v2 sku.
+Review and apply best practices for Web Application Firewall (WAF) on Azure Application Gateway.
 
 **Resources**
 
-- [Web Application Firewall policy overview](https://learn.microsoft.com/azure/web-application-firewall/ag/policy-overview)
+- [Best practices for Web Application Firewall on Application Gateway](https://learn.microsoft.com/azure/web-application-firewall/ag/best-practices)
 
 **Resource Graph Query/Scripts**
 
@@ -54,18 +51,17 @@ When you create a policy of WAF, it must be associated to an application gateway
 
 <br><br>
 
-### WAF-2 - Associate Web Application Firewall with Azure Front Door
+### WAF-2 - Review best practice for Web Application Firewall on Azure Front Door
 
-**Impact: High**
+**Impact: Medium**
 
 **Guidance**
 
-Azure Web Application Firewall (WAF) on Azure Front Door provides centralized protection for your web applications. WAF defends your web services against common exploits and vulnerabilities. It keeps your service highly available for your users and helps you meet compliance requirements.
-Azure Front Door has two tiers: Front Door Standard and Front Door Premium. WAF is natively integrated with Front Door Premium with full capabilities. For Front Door Standard, only custom rules are supported.
+Review and apply best practices for Web Application Firewall (WAF) on Azure Front Door.
 
 **Resources**
 
-- [Azure Web Application Firewall on Azure Front Door](https://learn.microsoft.com/azure/web-application-firewall/afds/afds-overview)
+- [Best practices for Web Application Firewall (WAF) on Azure Front Door](https://learn.microsoft.com/azure/web-application-firewall/afds/waf-front-door-best-practices)
 
 **Resource Graph Query/Scripts**
 
@@ -77,17 +73,20 @@ Azure Front Door has two tiers: Front Door Standard and Front Door Premium. WAF 
 
 <br><br>
 
-### WAF-3 - Review best practice for Web Application Firewall on Azure Application Gateway
+### WAF-3 - Review logs for Web Application Firewall on Azure Front Door for legitimate requests that are blocked
 
-**Impact: Medium**
+**Impact: High**
 
 **Guidance**
 
-Review and apply best practices for using the web application firewall (WAF) on Azure Application Gateway.
+WAF could block a legitimate request that it shouldn't (a false positive). You can identify requests that have been blocked within the last 24 hours through Log Analytics.
 
 **Resources**
 
-- [Best practices for Web Application Firewall on Application Gateway](https://learn.microsoft.com/azure/web-application-firewall/ag/best-practices)
+- [Azure Web Application Firewall monitoring and logging - Access Log](https://learn.microsoft.com/azure/web-application-firewall/afds/waf-front-door-monitor?pivots=front-door-standard-premium#access-logs)
+- [Understanding WAF logs](https://learn.microsoft.com/azure/web-application-firewall/afds/waf-front-door-tuning?pivots=front-door-standard-premium#understanding-waf-logs)
+- [Web Application Firewall exclusion lists](https://learn.microsoft.com/azure/web-application-firewall/ag/application-gateway-waf-configuration?tabs=portal)
+- [Fixing a false positive](https://learn.microsoft.com/azure/web-application-firewall/ag/web-application-firewall-troubleshoot#fixing-false-positives)
 
 **Resource Graph Query/Scripts**
 
@@ -99,17 +98,20 @@ Review and apply best practices for using the web application firewall (WAF) on 
 
 <br><br>
 
-### WAF-4 - Review best practice for Web Application Firewall on Azure Front Door
+### WAF-4 - Review logs for Web Application Firewall on Azure Application Gateway for legitimate requests that are blocked
 
-**Impact: Medium**
+**Impact: High**
 
 **Guidance**
 
-Review and apply best practices for using the web application firewall (WAF) on Azure Front Door.
+WAF could block a legitimate request that it shouldn't (a false positive). You can identify requests that have been blocked within the last 24 hours through Log Analytics.
 
 **Resources**
 
-- [Best practices for Web Application Firewall (WAF) on Azure Front Door](https://learn.microsoft.com/azure/web-application-firewall/afds/waf-front-door-best-practices)
+- [Azure Web Application Firewall Monitoring and Logging](https://learn.microsoft.com/azure/web-application-firewall/ag/application-gateway-waf-metrics#logs-and-diagnostics)
+- [Diagnostic logs](https://learn.microsoft.com/azure/web-application-firewall/ag/web-application-firewall-logs#diagnostic-logs)
+- [Web Application Firewall exclusion lists](https://learn.microsoft.com/azure/web-application-firewall/ag/application-gateway-waf-configuration?tabs=portal)
+- [Fixing a false positive](https://learn.microsoft.com/azure/web-application-firewall/ag/web-application-firewall-troubleshoot#fixing-false-positives)
 
 **Resource Graph Query/Scripts**
 
@@ -121,82 +123,13 @@ Review and apply best practices for using the web application firewall (WAF) on 
 
 <br><br>
 
-### WAF-5 - Identify a blocked legitimate request for Web Application Firewall on Azure Front Door
-
-**Impact: High**
-
-**Guidance**
-
-WAF could blocks a legitimate request that it shouldn't (a false positive). You can identify requests that have been blocked within the last 24 hours through Log Analytics.
-
-**Resources**
-
-- [Azure Web Application Firewall monitoring and logging - Access Log](https://learn.microsoft.com/azure/web-application-firewall/afds/waf-front-door-monitor?pivots=front-door-standard-premium#access-logs)
-- [Understanding WAF logs](https://learn.microsoft.com/azure/web-application-firewall/afds/waf-front-door-tuning?pivots=front-door-standard-premium#understanding-waf-logs)
-
-**Resource Graph Query/Scripts**
-
-{{< collapse title="Show/Hide Query/Script" >}}
-
-{{< code lang="sql" file="code/waf-5/waf-5.kql" >}} {{< /code >}}
-
-{{< /collapse >}}
-
-<br><br>
-
-### WAF-6 - Identify a blocked legitimate request for Web Application Firewall on Azure Application Gateway
-
-**Impact: High**
-
-**Guidance**
-
-WAF could blocks a legitimate request that it shouldn't (a false positive). You can identify requests that have been blocked within the last 24 hours through Log Analytics.
-
-**Resources**
-
-- [Azure Web Application Firewall Monitoring and Logging](https://learn.microsoft.com/azure/web-application-firewall/ag/application-gateway-waf-metrics#logs-and-diagnostics)
-- [Diagnostic logs](https://learn.microsoft.com/azure/web-application-firewall/ag/web-application-firewall-logs#diagnostic-logs)
-
-**Resource Graph Query/Scripts**
-
-{{< collapse title="Show/Hide Query/Script" >}}
-
-{{< code lang="sql" file="code/waf-6/waf-6.kql" >}} {{< /code >}}
-
-{{< /collapse >}}
-
-<br><br>
-
-### WAF-7 - Fixing a false positive for Web Application Firewall on Azure Application Gateway
-
-**Impact: High**
-
-**Guidance**
-
-WAF could blocks a legitimate request that it shouldn't (a false positive). The rule 942130 is the one that matched the 1=1 string, you can do a few things to stop this from blocking your traffic.
-
-**Resources**
-
-- [Web Application Firewall exclusion lists](https://learn.microsoft.com/azure/web-application-firewall/ag/application-gateway-waf-configuration?tabs=portal)
-- [Fixing a false positive](https://learn.microsoft.com/azure/web-application-firewall/ag/web-application-firewall-troubleshoot#fixing-false-positives)
-
-**Resource Graph Query/Scripts**
-
-{{< collapse title="Show/Hide Query/Script" >}}
-
-{{< code lang="sql" file="code/waf-7/waf-7.kql" >}} {{< /code >}}
-
-{{< /collapse >}}
-
-<br><br>
-
-### WAF-8 - Monitor Web Application Firewall
+### WAF-5 - Monitor Web Application Firewall
 
 **Impact: Medium**
 
 **Guidance**
 
-Monitoring the health of your application gateway is important. Monitoring the health of your WAF and the applications that it protects are supported by integration with Microsoft Defender for Cloud, Azure Monitor, and Azure Monitor logs.
+Monitoring the health of your WAF and the applications that it protects is important. Health monitoring is supported by integration with Microsoft Defender for Cloud, Azure Monitor, and Azure Monitor logs.
 
 **Resources**
 
@@ -207,7 +140,7 @@ Monitoring the health of your application gateway is important. Monitoring the h
 
 {{< collapse title="Show/Hide Query/Script" >}}
 
-{{< code lang="sql" file="code/waf-8/waf-8.kql" >}} {{< /code >}}
+{{< code lang="sql" file="code/waf-5/waf-5.kql" >}} {{< /code >}}
 
 {{< /collapse >}}
 

--- a/docs/content/services/networking/web-application-firewall/code/waf-1/waf-1.kql
+++ b/docs/content/services/networking/web-application-firewall/code/waf-1/waf-1.kql
@@ -1,5 +1,1 @@
-resources
-| where type == "microsoft.network/applicationgateways"
-| extend s = tostring(properties.sku.tier)
-| where s != "WAF_v2"
-| project id, name, resourceGroup, properties.sku.tier, subscriptionId
+// cannot-be-validated-with-arg

--- a/docs/content/services/networking/web-application-firewall/code/waf-2/waf-2.kql
+++ b/docs/content/services/networking/web-application-firewall/code/waf-2/waf-2.kql
@@ -1,5 +1,1 @@
-resources
-| where type == "microsoft.cdn/profiles"
-| extend s = tostring(sku.name)
-| where s != "Premium_AzureFrontDoor"
-| project id, name, resourceGroup, sku.name, subscriptionId
+// cannot-be-validated-with-arg

--- a/docs/content/services/networking/web-application-firewall/code/waf-3/waf-3.kql
+++ b/docs/content/services/networking/web-application-firewall/code/waf-3/waf-3.kql
@@ -1,1 +1,1 @@
-// In development
+// cannot-be-validated-with-arg

--- a/docs/content/services/networking/web-application-firewall/code/waf-4/waf-4.kql
+++ b/docs/content/services/networking/web-application-firewall/code/waf-4/waf-4.kql
@@ -1,1 +1,1 @@
-// In development
+// cannot-be-validated-with-arg

--- a/docs/content/services/networking/web-application-firewall/code/waf-5/waf-5.kql
+++ b/docs/content/services/networking/web-application-firewall/code/waf-5/waf-5.kql
@@ -1,4 +1,1 @@
-AzureDiagnostics
-| where Category == 'FrontDoorWebApplicationFirewallLog'
-| where TimeGenerated > ago(1d)
-| where action_s == 'Block'
+// cannot-be-validated-with-arg

--- a/docs/content/services/networking/web-application-firewall/code/waf-6/waf-6.kql
+++ b/docs/content/services/networking/web-application-firewall/code/waf-6/waf-6.kql
@@ -1,4 +1,0 @@
-AzureDiagnostics
-| where Category == 'ApplicationGatewayFirewallLog'
-| where TimeGenerated > ago(1d)
-| where action_s == 'Block'

--- a/docs/content/services/networking/web-application-firewall/code/waf-7/waf-7.kql
+++ b/docs/content/services/networking/web-application-firewall/code/waf-7/waf-7.kql
@@ -1,1 +1,0 @@
-// In development

--- a/docs/content/services/networking/web-application-firewall/code/waf-8/waf-8.kql
+++ b/docs/content/services/networking/web-application-firewall/code/waf-8/waf-8.kql
@@ -1,1 +1,0 @@
-// In development


### PR DESCRIPTION

# Overview/Summary

Updates to APRL WAF section, minor correction to AGW section
Validated locally using hugo.


## Related Issues/Work Items
AB#31327
AB#31328
AB#31329
AB#31330


## This PR fixes/adds/changes/removes

Removed original WAF-1, duplicate of AGW-3
Removed original WAF-2, duplicate of AFD-10
Removed original WAF-7. This was incorporated into guidance for the now WAF-3 and WAF-4. 
Updated content of all WAF .kql files with "// cannot-be-validated-with-arg" 
Minor grammar/syntax updates in WAF's _index.md

### Breaking Changes

1. *Replace me*
2. *Replace me*

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
