### PR TITLE
Adding more requirements for PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,5 +28,5 @@ Replace this with a list of related GitHub Issues and/or ADO Work Items (Interna
 - [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
 - [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
 - [ ] Ensured PR tests are passing
-- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries and/or scripts (e.g. screenshot)
+- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries and/or scripts
 - [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,4 +28,5 @@ Replace this with a list of related GitHub Issues and/or ADO Work Items (Interna
 - [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
 - [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
 - [ ] Ensured PR tests are passing
+- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries and/or scripts (e.g. screenshot)
 - [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # The aprl-admins team is responsible for reviewing and merging PRs
 
 # The following team members have ownership
-/ @Azure/aprl-admins
+* @Azure/aprl-admins

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# The aprl-admins team is responsible for reviewing and merging PRs
+
+# The following team members have ownership
+/ @Azure/aprl-admins

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,2 @@
 # The aprl-admins team is responsible for reviewing and merging PRs
-
-# The following team members have ownership
 * @Azure/aprl-admins


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Increase PR validation requirements from an admin and contributor perspective. 

## Related Issues/Work Items

Replace this with a list of related GitHub Issues and/or ADO Work Items (Internal Only)

- To associate a GitHub Issue, use a [key word](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) preceded with the GitHub issue number.
- To associate an ADO Work Item, use the key word `AB#` succeeded with the [ADO Work Item ID](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

## This PR fixes/adds/changes/removes

1. Add codeowners file for ensuring that PRs have validation by particular team members.
2. Add checkbox in PR form to make sure contributors are including screenshots of testing their queries/scripts.

### Breaking Changes


## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
