### PR TITLE
fix typo in query vm-5

### DIFF
--- a/docs/content/services/compute/virtual-machines/code/vm-5/vm-5.kql
+++ b/docs/content/services/compute/virtual-machines/code/vm-5/vm-5.kql
@@ -3,4 +3,4 @@
 Resources
 | where type =~ 'Microsoft.Compute/virtualMachines'
 | where isnull(properties.storageProfile.osDisk.managedDisk)
-| project recommendationId = "vm-9", name, id
+| project recommendationId = "vm-5", name, id


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

fix typo in query vm-5

## Related Issues/Work Items

NA


## This PR fixes/adds/changes/removes

1. Fixed recommendationId in query that should be "vm-5", but it was "vm-9".

### Breaking Changes

1. None

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
- [x] Ensured PR tests are passing
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries and/or scripts
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
