### PR TITLE
lb-1 query fixed

### DIFF
--- a/docs/content/services/networking/load-balancer/_index.md
+++ b/docs/content/services/networking/load-balancer/_index.md
@@ -16,7 +16,7 @@ The below table shows the list of resiliency recommendations for Load Balancer a
 {{< table style="table-striped" >}}
 | Recommendation                                    |  Impact  |  State   | ARG Query Available |
 | :------------------------------------------------ | :------: | :------: | :-----------------: |
-| [LB-1 - Use Standard Load Balancer SKU](#lb-1---use-standard-load-balancer-sku) | High | Preview  |  No         |
+| [LB-1 - Use Standard Load Balancer SKU](#lb-1---use-standard-load-balancer-sku) | High | Preview  |  Yes         |
 | [LB-2 - Ensure the Backend Pool contains at least two instances](#lb-2---ensure-the-backend-pool-contains-at-least-two-instances) | High | Preview |   Yes          |
 | [LB-3 - Use NAT Gateway instead of Outbound Rules for Production Workloads](#lb-3---use-nat-gateway-instead-of-outbound-rules-for-production-workloads) | Medium | Preview |    Yes          |
 | [LB-4 - Ensure Standard Load Balancer is zone-redundant](#lb-4---ensure-standard-load-balancer-is-zone-redundant) | High | Preview | Yes |

--- a/docs/content/services/networking/load-balancer/code/lb-1/lb-1.kql
+++ b/docs/content/services/networking/load-balancer/code/lb-1/lb-1.kql
@@ -1,1 +1,6 @@
-// under-development
+// Azure Resource Graph Query
+// Find all LoadBalancers using Basic SKU
+resources
+| where type =~ 'Microsoft.Network/loadBalancers'
+| where sku.name == 'Basic'
+| project recommendationId = "lb-1", name, id, Param1=strcat("sku-tier: basic")

--- a/docs/content/services/networking/load-balancer/code/lb-1/lb-1.kql.fix
+++ b/docs/content/services/networking/load-balancer/code/lb-1/lb-1.kql.fix
@@ -1,7 +1,0 @@
-// Azure Resource Graph Query
-// Find all LoadBalancers using Basic SKU
-resources
-| where type =~ 'Microsoft.Network/loadbalancers'
-| extend sku = tostring(sku.name)
-| where sku == 'Basic'
-| project recommendationId = "lb-1", name, id, sku


### PR DESCRIPTION
# Overview/Summary

Fixed the query for lb-1

![image](https://github.com/Azure/Azure-Proactive-Resiliency-Library/assets/30884663/509096fc-1da3-49c7-acb6-47bab7117a6c)


![image](https://github.com/Azure/Azure-Proactive-Resiliency-Library/assets/30884663/241c0f72-d988-4029-9f6d-91715403da59)

## Related Issues/Work Items


## This PR fixes/adds/changes/removes


### Breaking Changes

none

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
- [x] Ensured PR tests are passing
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries and/or scripts
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
