### PR TITLE
Adding Tags to VM Queries in APRL

### DIFF
--- a/docs/content/services/compute/virtual-machines/code/vm-10/vm-10.kql
+++ b/docs/content/services/compute/virtual-machines/code/vm-10/vm-10.kql
@@ -1,15 +1,15 @@
 // Azure Resource Graph Query
 // Find all VM NICs that do not have Accelerated Networking enabled
-Resources
+resources
 | where type =~ 'Microsoft.Compute/virtualMachines'
 | mv-expand nic=properties.networkProfile.networkInterfaces
-| project name, id, nicName = tostring(split(tostring(nic.id), '/')[8])
+| project name, id, tags, nicName = tostring(split(tostring(nic.id), '/')[8])
 | join kind=inner (
-    Resources
+    resources
     | where type =~ 'Microsoft.Network/networkInterfaces'
     | where properties.enableAcceleratedNetworking == false
     | project nicName = tostring(split(tostring(id), '/')[8])
 ) on nicName
-| summarize NicNames = make_set(nicName) by name, id
-| project recommendationId = "vm-10", name, id, param1=NicNames
+| summarize NicNames = make_set(nicName) by name, id, tostring(tags)
+| project recommendationId = "vm-10", name, id, tags, param1=strcat("nicNames: ", NicNames)
 | order by id asc

--- a/docs/content/services/compute/virtual-machines/code/vm-11/vm-11.kql
+++ b/docs/content/services/compute/virtual-machines/code/vm-11/vm-11.kql
@@ -3,12 +3,12 @@
 Resources
 | where type =~ 'Microsoft.Compute/virtualMachines'
 | mv-expand nic=properties.networkProfile.networkInterfaces
-| project name, id, nicName = tostring(split(tostring(nic.id), '/')[8])
+| project name, id, nicName = tostring(split(tostring(nic.id), '/')[8]), tags
 | join kind=inner (
     Resources
     | where type =~ 'Microsoft.Network/networkInterfaces'
     | where properties.enableAcceleratedNetworking == true
     | project nicName = tostring(split(tostring(id), '/')[8])
 ) on nicName
-| project recommendationId = "vm-11", name, id
+| project recommendationId = "vm-11", name, id, tags
 | order by id asc

--- a/docs/content/services/compute/virtual-machines/code/vm-12/vm-12.kql
+++ b/docs/content/services/compute/virtual-machines/code/vm-12/vm-12.kql
@@ -4,7 +4,7 @@ Resources
 | where type =~ 'Microsoft.Compute/virtualMachines'
 | where isnotnull(properties.networkProfile.networkInterfaces)
 | mv-expand nic=properties.networkProfile.networkInterfaces
-| project name, id, nicId = nic.id
+| project name, id, tags, nicId = nic.id
 | extend nicId = tostring(nicId)
 | join kind=inner (
     Resources
@@ -15,5 +15,5 @@ Resources
     | where publicIp != ""
     | project name, nicId = tostring(id), publicIp
 ) on nicId
-| project recommendationId = "vm-12", name, id
+| project recommendationId = "vm-12", name, id, tags
 | order by id asc

--- a/docs/content/services/compute/virtual-machines/code/vm-14/vm-14.kql
+++ b/docs/content/services/compute/virtual-machines/code/vm-14/vm-14.kql
@@ -4,7 +4,7 @@ Resources
 | where type =~ 'Microsoft.Compute/virtualMachines'
 | where isnotnull(properties.networkProfile.networkInterfaces)
 | mv-expand nic=properties.networkProfile.networkInterfaces
-| project name, id, nicId = nic.id
+| project name, id, tags, nicId = nic.id
 | extend nicId = tostring(nicId)
 | join kind=inner (
     Resources
@@ -12,5 +12,5 @@ Resources
     | where properties.enableIPForwarding == true
     | project nicId = tostring(id)
 ) on nicId
-| project recommendationId = "vm-14", name, id
+| project recommendationId = "vm-14", name, id, tags
 | order by id asc

--- a/docs/content/services/compute/virtual-machines/code/vm-15/vm-15.kql
+++ b/docs/content/services/compute/virtual-machines/code/vm-15/vm-15.kql
@@ -4,7 +4,7 @@ Resources
 | where type =~ 'Microsoft.Compute/virtualMachines'
 | where isnotnull(properties.networkProfile.networkInterfaces)
 | mv-expand nic=properties.networkProfile.networkInterfaces
-| project name, id, nicId = nic.id
+| project name, id, tags, nicId = nic.id
 | extend nicId = tostring(nicId)
 | join kind=inner (
     Resources
@@ -14,5 +14,5 @@ Resources
     | where hasDns != 0
     | project name, nicId = tostring(id)
 ) on nicId
-| project recommendationId = "vm-15", name, id
+| project recommendationId = "vm-15", name, id, tags
 | order by id asc

--- a/docs/content/services/compute/virtual-machines/code/vm-16/vm-16.kql
+++ b/docs/content/services/compute/virtual-machines/code/vm-16/vm-16.kql
@@ -3,5 +3,5 @@
 Resources
 | where type =~ 'Microsoft.Compute/disks'
 | where isnotnull(properties.maxShares)
-| project recommendationId = "vm-16", name, id
+| project recommendationId = "vm-16", name, id, tags
 | order by id asc

--- a/docs/content/services/compute/virtual-machines/code/vm-17/vm-17.kql
+++ b/docs/content/services/compute/virtual-machines/code/vm-17/vm-17.kql
@@ -3,5 +3,5 @@
 Resources
 | where type =~ 'Microsoft.Compute/disks'
 | where properties.publicNetworkAccess == "Enabled"
-| project recommendationId = "vm-17", name, id
+| project recommendationId = "vm-17", name, id, tags
 | order by id asc

--- a/docs/content/services/compute/virtual-machines/code/vm-18/vm-18.kql
+++ b/docs/content/services/compute/virtual-machines/code/vm-18/vm-18.kql
@@ -5,4 +5,4 @@ PolicyResources
 | where properties.complianceState == 'NonCompliant'
 | extend vmResourceId = properties.resourceId, vmresourceType = properties.resourceType, PolicyAssignmentName = properties.policyAssignmentName
 | where vmresourceType == 'Microsoft.Compute/virtualMachines'
-| project recommendationId = "vm-18", name = tostring(split(tostring(properties.resourceId), '/')[8]), id=vmResourceId, param1 = strcat ("Policyname: ", name)
+| project recommendationId = "vm-18", name = tostring(split(tostring(properties.resourceId), '/')[8]), id=vmResourceId, tags, param1 = strcat ("Policyname: ", name)

--- a/docs/content/services/compute/virtual-machines/code/vm-19/vm-19.kql
+++ b/docs/content/services/compute/virtual-machines/code/vm-19/vm-19.kql
@@ -5,4 +5,4 @@ resources
 | extend encryptionType = properties.encryption.type
 | extend diskState = properties.diskState
 | where encryptionType !in ("EncryptionAtRestWithCustomerKey", "EncryptionAtRestWithPlatformAndCustomerKeys", "EncryptionAtRestWithPlatformKey")
-| project recommendationId="vm-19", name, id, param1=strcat("encryptionType: " , properties.encryption.type), param2= strcat ("diskstate: ", properties.diskState)
+| project recommendationId="vm-19", name, id, tags, param1=strcat("encryptionType: " , properties.encryption.type), param2= strcat ("diskstate: ", properties.diskState)

--- a/docs/content/services/compute/virtual-machines/code/vm-2/vm-2.kql
+++ b/docs/content/services/compute/virtual-machines/code/vm-2/vm-2.kql
@@ -3,4 +3,4 @@
 Resources
 | where type =~ 'Microsoft.Compute/virtualMachines'
 | where isnull(zones)
-| project recommendationId = "vm-2", name, id, param1="Zones: No Zone"
+| project recommendationId="vm-2", name, id, tags, param1="No Zone"

--- a/docs/content/services/compute/virtual-machines/code/vm-20/vm-20.kql
+++ b/docs/content/services/compute/virtual-machines/code/vm-20/vm-20.kql
@@ -13,6 +13,6 @@ resources
         VMId = toupper(substring(id, 0, indexof(id, '/extensions'))),
         ExtensionName = name
 ) on $left.JoinID == $right.VMId
-| summarize param2 = strcat ("Extensions: ", make_list(ExtensionName)) by recommendationId="vm-20", name=vmName, id, param1=OSType
+| summarize param2 = strcat ("Extensions: ", make_list(ExtensionName)) by recommendationId="vm-20", name=vmName, id, tags=strcat(tags), param1=OSType
 | where param2 !contains "MicrosoftMonitoringAgent" and param2 !contains "OMSAgentforLinux" and param2 !contains "AzureMonitorWindowsAgent" and param2 !contains "AzureMonitorLinuxAgent"
 | order by tolower(name) asc

--- a/docs/content/services/compute/virtual-machines/code/vm-22/vm-22.kql
+++ b/docs/content/services/compute/virtual-machines/code/vm-22/vm-22.kql
@@ -2,7 +2,7 @@
 // Find VMS that do not have maintenance configuration assigned
 Resources
 | extend resourceId = tolower(id)
-| project name, location, type, id, resourceId, properties
+| project name, location, type, id, tags, resourceId, properties
 | where type =~ 'Microsoft.Compute/virtualMachines'
 | join kind=leftouter (
 maintenanceresources
@@ -11,5 +11,5 @@ maintenanceresources
 | extend resourceId = tostring(maintenanceProps.resourceId)
 ) on resourceId
 | where isnull(maintenanceProps)
-| project recommendationId = "vm-22",name, id
+| project recommendationId = "vm-22",name, id, tags
 | order by id asc

--- a/docs/content/services/compute/virtual-machines/code/vm-4/vm-4.kql
+++ b/docs/content/services/compute/virtual-machines/code/vm-4/vm-4.kql
@@ -3,7 +3,7 @@
 // Run query to see results.
 resources
 | where type =~ 'Microsoft.Compute/virtualMachines'
-| project name, id
+| project name, id, tags
 | join kind=leftouter (
     recoveryservicesresources
     | where type =~ 'Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems'
@@ -14,5 +14,5 @@ resources
 | where isnull(id1)
 | project-away id1
 | project-away name1
-| project recommendationId = "vm-4", name, id
+| project recommendationId = "vm-4", name, id, tags
 | order by id asc

--- a/docs/content/services/compute/virtual-machines/code/vm-5/vm-5.kql
+++ b/docs/content/services/compute/virtual-machines/code/vm-5/vm-5.kql
@@ -3,4 +3,4 @@
 Resources
 | where type =~ 'Microsoft.Compute/virtualMachines'
 | where isnull(properties.storageProfile.osDisk.managedDisk)
-| project recommendationId = "vm-5", name, id
+| project recommendationId = "vm-5", name, id, tags

--- a/docs/content/services/compute/virtual-machines/code/vm-6/vm-6.kql
+++ b/docs/content/services/compute/virtual-machines/code/vm-6/vm-6.kql
@@ -3,4 +3,4 @@
 Resources
 | where type =~ 'Microsoft.Compute/virtualMachines'
 | where array_length(properties.storageProfile.dataDisks) < 1
-| project recommendationId = "vm-6", name, id
+| project recommendationId = "vm-6", name, id, tags

--- a/docs/content/services/compute/virtual-machines/code/vm-7/vm-7.kql
+++ b/docs/content/services/compute/virtual-machines/code/vm-7/vm-7.kql
@@ -3,7 +3,7 @@
 // Run query to see results.
 resources
 | where type =~ 'Microsoft.Compute/virtualMachines'
-| project name, id
+| project name, id, tags
 | join kind=leftouter (
     recoveryservicesresources
     | where type =~ 'Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems'
@@ -14,5 +14,5 @@ resources
 | where isnull(idBackupEnabled)
 | project-away idBackupEnabled
 | project-away name1
-| project recommendationId = "vm-7", name, id
+| project recommendationId = "vm-7", name, id, tags
 | order by id asc

--- a/docs/content/services/compute/virtual-machines/code/vm-8/vm-8.kql
+++ b/docs/content/services/compute/virtual-machines/code/vm-8/vm-8.kql
@@ -4,4 +4,4 @@ Resources
 | where type =~ 'Microsoft.Compute/disks'
 | where sku.name == 'Standard_LRS' and sku.tier == 'Standard'
 | where managedBy != ""
-| project recommendationId = "vm-8", name, id, param1=strcat("managedBy: ", managedBy)
+| project recommendationId = "vm-8", name, id, tags, param1=strcat("managedBy: ", managedBy)

--- a/docs/content/services/compute/virtual-machines/code/vm-9/vm-9.kql
+++ b/docs/content/services/compute/virtual-machines/code/vm-9/vm-9.kql
@@ -3,4 +3,4 @@
 Resources
 | where type =~ 'Microsoft.Compute/virtualMachines'
 | where properties.extended.instanceView.powerState.displayStatus != 'VM running'
-| project recommendationId = "vm-9", name, id
+| project recommendationId = "vm-9", name, id, tags


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
In all the available queries in the Virtual Machines section (total 18/22) in APRL, I added "tags" that are associated with the VMs in question by the queries as a column in the results

Replace this with a brief description of what this Pull Request fixes, changes, etc.

Adds tags to existing VM queries

[AB#32174](https://dev.azure.com/CSUSolEng/12ba7e46-a92a-47f6-ad6a-fba0479234a7/_workitems/edit/32174) 

## This PR fixes/adds/changes/removes

1. adds tags to VM-2, 4-12, 14-20, 22 query files

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
- [x] Ensured PR tests are passing
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries and/or scripts
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
