### PR TITLE
Updated KQL for VMSS Recommendations

### DIFF
--- a/docs/content/services/compute/virtual-machine-scale-sets/_index.md
+++ b/docs/content/services/compute/virtual-machine-scale-sets/_index.md
@@ -247,7 +247,7 @@ When you create your VMSS, use availability zones to protect your applications a
 
 **Guidance**
 
-Enabling automatic VM guest patching for your Azure VMs helps ease update management by safely and automatically patching virtual machines to maintain security compliance, while limiting the blast radius of VMs.
+Enabling automatic VM guest patching for your Azure VMs helps ease update management by safely and automatically patching virtual machines to maintain security compliance, while limiting the blast radius of VMs. Note that the KQL below will not return Virtual Machine Scale Sets using Uniform orchestration.
 
 **Resources**
 

--- a/docs/content/services/compute/virtual-machine-scale-sets/code/vmss-2/vmss-2.kql
+++ b/docs/content/services/compute/virtual-machine-scale-sets/code/vmss-2/vmss-2.kql
@@ -10,4 +10,4 @@ resources
     | project id
 ) on id
 | where id1 == ""
-| project recommendationId = "vmss-2", name, id, param1 = "extension: ApplicationHealth"
+| project recommendationId = "vmss-2", name, id, param1 = "extension: null"

--- a/docs/content/services/compute/virtual-machine-scale-sets/code/vmss-2/vmss-2.kql
+++ b/docs/content/services/compute/virtual-machine-scale-sets/code/vmss-2/vmss-2.kql
@@ -1,1 +1,13 @@
-// under-development
+// Azure Resource Graph Query
+// Find all VMs that do NOT have health monitoring enabled
+resources
+| where type == "microsoft.compute/virtualmachinescalesets"
+| join kind=leftouter  (
+    resources
+    | where type == "microsoft.compute/virtualmachinescalesets"
+    | mv-expand extension=properties.virtualMachineProfile.extensionProfile.extensions
+    | where extension.properties.type in ( "ApplicationHealthWindows", "ApplicationHealthLinux" )
+    | project id
+) on id
+| where id1 == ""
+| project recommendationId = "vmss-2", name, id, param1 = "extension: ApplicationHealth"

--- a/docs/content/services/compute/virtual-machine-scale-sets/code/vmss-3/vmss-3.kql
+++ b/docs/content/services/compute/virtual-machine-scale-sets/code/vmss-3/vmss-3.kql
@@ -3,4 +3,4 @@
 resources
 | where type == "microsoft.compute/virtualmachinescalesets"
 | where properties.automaticRepairsPolicy.enabled == false
-| project recommendationId = "vmss-3", name, id, param1 = "automaticRepairsPolicy: Enabled"
+| project recommendationId = "vmss-3", name, id, param1 = "automaticRepairsPolicy: Disabled"

--- a/docs/content/services/compute/virtual-machine-scale-sets/code/vmss-3/vmss-3.kql
+++ b/docs/content/services/compute/virtual-machine-scale-sets/code/vmss-3/vmss-3.kql
@@ -1,1 +1,6 @@
-// under-development
+// Azure Resource Graph Query
+// Find all VMs that do NOT have automatic repair policy enabled
+resources
+| where type == "microsoft.compute/virtualmachinescalesets"
+| where properties.automaticRepairsPolicy.enabled == false
+| project recommendationId = "vmss-3", name, id, param1 = "automaticRepairsPolicy: Enabled"

--- a/docs/content/services/compute/virtual-machine-scale-sets/code/vmss-4/vmss-4.kql
+++ b/docs/content/services/compute/virtual-machine-scale-sets/code/vmss-4/vmss-4.kql
@@ -10,5 +10,5 @@ resources
     | project id = tostring(properties.targetResourceUri), autoscalesettings = properties
 ) on id
 | where isnull(autoscalesettings) or autoscalesettings.enabled == "false"
-| project recommendationId = "vmss-4", name, id, param1 = "autoscalesettings: Manual"
+| project recommendationId = "vmss-4", name, id, param1 = "autoscalesettings: Enabled"
 | order by id asc

--- a/docs/content/services/compute/virtual-machine-scale-sets/code/vmss-4/vmss-4.kql
+++ b/docs/content/services/compute/virtual-machine-scale-sets/code/vmss-4/vmss-4.kql
@@ -10,5 +10,5 @@ resources
     | project id = tostring(properties.targetResourceUri), autoscalesettings = properties
 ) on id
 | where isnull(autoscalesettings) or autoscalesettings.enabled == "false"
-| project recommendationId = "vmss-4", name, id, param1 = "autoscalesettings: Enabled"
+| project recommendationId = "vmss-4", name, id, param1 = "autoscalesettings: Disabled"
 | order by id asc

--- a/docs/content/services/compute/virtual-machine-scale-sets/code/vmss-9/vmss-9.kql
+++ b/docs/content/services/compute/virtual-machine-scale-sets/code/vmss-9/vmss-9.kql
@@ -1,1 +1,10 @@
-// under-development
+// Azure Resource Graph Query
+// Find VMSS instances that do NOT have automatic VM guest patching enabled
+resources
+| where type == "microsoft.compute/virtualmachinescalesets"
+| where isnotnull(properties.virtualMachineProfile.osProfile.windowsConfiguration) and properties.virtualMachineProfile.osProfile.windowsConfiguration.patchSettings.patchMode != "AutomaticByPlatform"
+| project recommendationId = "vmss-9", name, id, param1 = "patchMode: AutomaticByPlatform"
+| union (resources
+| where type == "microsoft.compute/virtualmachinescalesets"
+| where isnotnull(properties.virtualMachineProfile.osProfile.linuxConfiguration) and properties.virtualMachineProfile.osProfile.linuxConfiguration.patchSettings.patchMode != "AutomaticByPlatform"
+| project recommendationId = "vmss-9", name, id, param1 = "patchMode: AutomaticByPlatform")

--- a/docs/content/services/compute/virtual-machine-scale-sets/code/vmss-9/vmss-9.kql
+++ b/docs/content/services/compute/virtual-machine-scale-sets/code/vmss-9/vmss-9.kql
@@ -1,10 +1,20 @@
-// Azure Resource Graph Query
-// Find VMSS instances that do NOT have automatic VM guest patching enabled
 resources
 | where type == "microsoft.compute/virtualmachinescalesets"
-| where isnotnull(properties.virtualMachineProfile.osProfile.windowsConfiguration) and properties.virtualMachineProfile.osProfile.windowsConfiguration.patchSettings.patchMode != "AutomaticByPlatform"
-| project recommendationId = "vmss-9", name, id, param1 = "patchMode: AutomaticByPlatform"
+| join kind=inner (
+    resources
+    | where type == "microsoft.compute/virtualmachines"
+    | project id = tostring(properties.virtualMachineScaleSet.id), vmproperties = properties
+) on id
+| extend recommendationId = "vmss-9", param1 = "patchMode: Manual", vmproperties.osProfile.linuxConfiguration.patchSettings.patchMode
+| where isnotnull(vmproperties.osProfile.linuxConfiguration) and vmproperties.osProfile.linuxConfiguration.patchSettings.patchMode !in ("AutomaticByPlatform", "AutomaticByOS")
+| distinct recommendationId, name, id, param1
 | union (resources
 | where type == "microsoft.compute/virtualmachinescalesets"
-| where isnotnull(properties.virtualMachineProfile.osProfile.linuxConfiguration) and properties.virtualMachineProfile.osProfile.linuxConfiguration.patchSettings.patchMode != "AutomaticByPlatform"
-| project recommendationId = "vmss-9", name, id, param1 = "patchMode: AutomaticByPlatform")
+| join kind=inner (
+    resources
+    | where type == "microsoft.compute/virtualmachines"
+    | project id = tostring(properties.virtualMachineScaleSet.id), vmproperties = properties
+) on id
+| extend recommendationId = "vmss-9", param1 = "patchMode: Manual", vmproperties.osProfile.windowsConfiguration.patchSettings.patchMode
+| where isnotnull(vmproperties.osProfile.windowsConfiguration) and vmproperties.osProfile.windowsConfiguration.patchSettings.patchMode !in ("AutomaticByPlatform", "AutomaticByOS")
+| distinct recommendationId, name, id, param1)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Updated the KQL for VMSS Recommendations

## Related Issues/Work Items

AB#[32301](https://dev.azure.com/CSUSolEng/Azure%20Infra%20Compute/_workitems/edit/32301)

## This PR fixes/adds/changes/removes

1.  New KQL for [VMSS-2 - Enable VMSS application health monitoring](https://azure.github.io/Azure-Proactive-Resiliency-Library/services/compute/virtual-machine-scale-sets/#vmss-2---enable-vmss-application-health-monitoring)
2. New KQL for [VMSS-3 - Enable Automatic Repair policy](https://azure.github.io/Azure-Proactive-Resiliency-Library/services/compute/virtual-machine-scale-sets/#vmss-3---enable-automatic-repair-policy)
3. Updated KQL for [VMSS-4 - Configure VMSS Autoscale to custom and configure the scaling metrics](https://azure.github.io/Azure-Proactive-Resiliency-Library/services/compute/virtual-machine-scale-sets/#vmss-4---configure-vmss-autoscale-to-custom-and-configure-the-scaling-metrics)
4. New KQL for [VMSS-9 - Set Patch orchestration options to Azure-orchestrated](https://azure.github.io/Azure-Proactive-Resiliency-Library/services/compute/virtual-machine-scale-sets/#vmss-9---set-patch-orchestration-options-to-azure-orchestrated)

### Breaking Changes

## As part of this Pull Request I have

- [x ] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing) and ensured this PR is compliant with the guide
- [x ] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library/pulls)
- [x ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
- [ x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
- [ x] Ensured PR tests are passing
- [x ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries and/or scripts
- [ x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
