### PR TITLE
Fix the language highlight mode for the PowerShell code blocks for RT-1, RT-2

### DIFF
--- a/docs/content/services/networking/route-table/_index.md
+++ b/docs/content/services/networking/route-table/_index.md
@@ -44,7 +44,7 @@ Create Alerts for administrative operations such as Create or Update Route Table
 
 {{< collapse title="Show/Hide Query/Script" >}}
 
-{{< code lang="sql" file="code/rt-1/rt-1.ps1" >}} {{< /code >}}
+{{< code lang="powershell" file="code/rt-1/rt-1.ps1" >}} {{< /code >}}
 
 {{< /collapse >}}
 
@@ -69,7 +69,7 @@ You can set locks that prevent either deletions or modifications. In the portal,
 
 {{< collapse title="Show/Hide Query/Script" >}}
 
-{{< code lang="sql" file="code/rt-2/rt-2.ps1" >}} {{< /code >}}
+{{< code lang="powershell" file="code/rt-2/rt-2.ps1" >}} {{< /code >}}
 
 {{< /collapse >}}
 


### PR DESCRIPTION
# Overview/Summary

Fixed the language highlight mode for the PowerShell code blocks to `powershell` from `sql` for RT-1, RT-2.

## Related Issues/Work Items

- None

## This PR fixes/adds/changes/removes

1. Fixes the language highlight mode for the PowerShell code blocks to `powershell` from `sql` for RT-1, RT-2.

### Breaking Changes

- None

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
- [x] Ensured PR tests are passing
    - **Ensured the changes works fine on my local copy.**
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries and/or scripts
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
