### PR TITLE
Fix the language highlight mode for the PowerShell code blocks for ST-5, ST-6, ST-7, ST-8

### DIFF
--- a/docs/content/services/storage/storage-Account/_index.md
+++ b/docs/content/services/storage/storage-Account/_index.md
@@ -154,7 +154,7 @@ Soft delete option allow for recovering data if its deleted by mistaken. Moreove
 
 {{< collapse title="Show/Hide Query/Script" >}}
 
-{{< code lang="sql" file="/code/st-5/st-5.ps1" >}} {{< /code >}}
+{{< code lang="powershell" file="/code/st-5/st-5.ps1" >}} {{< /code >}}
 
 {{< /collapse >}}
 
@@ -179,7 +179,7 @@ Having a large number of versions per blob can increase the latency for blob lis
 
 {{< collapse title="Show/Hide Query/Script" >}}
 
-{{< code lang="sql" file="/code/st-6/st-6.ps1" >}} {{< /code >}}
+{{< code lang="powershell" file="/code/st-6/st-6.ps1" >}} {{< /code >}}
 
 {{< /collapse >}}
 
@@ -204,7 +204,7 @@ Point and time restore support general purpose v2 account in standard performanc
 
 {{< collapse title="Show/Hide Query/Script" >}}
 
-{{< code lang="sql" file="/code/st-7/st-7.ps1" >}} {{< /code >}}
+{{< code lang="powershell" file="/code/st-7/st-7.ps1" >}} {{< /code >}}
 
 {{< /collapse >}}
 
@@ -228,7 +228,7 @@ Enabling diagnostic settings allow you to capture and view diagnostic informatio
 
 {{< collapse title="Show/Hide Query/Script" >}}
 
-{{< code lang="sql" file="/code/st-8/st-8.ps1" >}} {{< /code >}}
+{{< code lang="powershell" file="/code/st-8/st-8.ps1" >}} {{< /code >}}
 
 {{< /collapse >}}
 


### PR DESCRIPTION
# Overview/Summary

Fixed the language highlight mode for the PowerShell code blocks to `powershell` from `sql` for ST-5, ST-6, ST-7, ST-8.

## Related Issues/Work Items

- None

## This PR fixes/adds/changes/removes

1. Fixes the language highlight mode for the PowerShell code blocks to `powershell` from `sql` for ST-5, ST-6, ST-7, ST-8.

### Breaking Changes

- None

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
- [x] Ensured PR tests are passing
    - **Ensured the changes work fine on my local copy.**
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries and/or scripts
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
