### PR TITLE
Fix the category of NSG-3

### DIFF
--- a/docs/content/services/networking/network-security-group/_index.md
+++ b/docs/content/services/networking/network-security-group/_index.md
@@ -79,7 +79,7 @@ Create Alerts for administrative operations such as Create or Update Network Sec
 
 ### NSG-3 - Configure locks for Network Security Groups to avoid accidental changes and/or deletion
 
-**Category: **
+**Category: Governance**
 
 **Impact: Medium**
 


### PR DESCRIPTION
# Overview/Summary

Fixed the category of NSG-3 to __Governance__ because it is empty.

- https://azure.github.io/Azure-Proactive-Resiliency-Library/services/networking/network-security-group/#nsg-3---configure-locks-for-network-security-groups-to-avoid-accidental-changes-andor-deletion

## Related Issues/Work Items

- None

## This PR fixes/adds/changes/removes

1. Fixes the category of NSG-3 to Governance.

### Breaking Changes

- None

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries and/or scripts
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
