### PR TITLE
Fix query result column for KV-1

### DIFF
--- a/docs/content/services/security/key-vault/code/kv-1/kv-1.kql
+++ b/docs/content/services/security/key-vault/code/kv-1/kv-1.kql
@@ -3,4 +3,4 @@
 resources
 | where type == "microsoft.keyvault/vaults"
 | where isnull(properties.enableSoftDelete) or properties.enableSoftDelete != "true"
-| project recommendationId = "kv-1", name, id, tags, param1 = strcat("softDeleteEnabled: disabled")
+| project recommendationId = "kv-1", name, id, tags, param1 = "softDeleteEnabled: disabled"

--- a/docs/content/services/security/key-vault/code/kv-1/kv-1.kql
+++ b/docs/content/services/security/key-vault/code/kv-1/kv-1.kql
@@ -3,4 +3,4 @@
 resources
 | where type == "microsoft.keyvault/vaults"
 | where isnull(properties.enableSoftDelete) or properties.enableSoftDelete != "true"
-| project recommendationId = "kv-1", name, id, tags, softDeleteEnabled = "disabled"
+| project recommendationId = "kv-1", name, id, tags, param1 = strcat("softDeleteEnabled: disabled")

--- a/docs/content/services/security/key-vault/code/kv-1/kv-1.kql
+++ b/docs/content/services/security/key-vault/code/kv-1/kv-1.kql
@@ -3,4 +3,4 @@
 resources
 | where type == "microsoft.keyvault/vaults"
 | where isnull(properties.enableSoftDelete) or properties.enableSoftDelete != "true"
-| project recommendationId = "kv-1", name, id, tags, param1 = "softDeleteEnabled: disabled"
+| project recommendationId = "kv-1", name, id, tags, param1 = "EnableSoftDelete: Disabled"


### PR DESCRIPTION
# Overview/Summary

Fixed a query result column of KV-1 to align [the Azure Resource Graph query standards](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing/#azure-resource-graph-arg-queries).

## Related Issues/Work Items

- None

## This PR fixes/adds/changes/removes

1. Fixes a query result column of KV-1 to `param1` from `softDeleteEnabled`.

### Breaking Changes

- None

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
- [ ] Ensured PR tests are passing
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries and/or scripts
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)

## Evidence

![image](https://github.com/Azure/Azure-Proactive-Resiliency-Library/assets/1618784/bca37770-be5b-4b8b-8416-3ff8270f1ab7)

