### PR TITLE
Fix query result columns for VNET-1

### DIFF
--- a/docs/content/services/networking/virtual-networks/code/vnet-1/vnet-1.kql
+++ b/docs/content/services/networking/virtual-networks/code/vnet-1/vnet-1.kql
@@ -5,4 +5,4 @@ resources
 | mv-expand subnets = properties.subnets
 | extend sn = string_size(subnets.properties.networkSecurityGroup)
 | where sn == 0
-| project recommendationId = "vnet-1", name, id, tags, subnets.name, NSG="NSG: False"
+| project recommendationId = "vnet-1", name, id, tags, param1 = strcat("SubnetName: ", subnets.name), param2 = "NSG: False"


### PR DESCRIPTION
# Overview/Summary

Fixed query result columns of VNET-1 to align [the Azure Resource Graph query standards](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing/#azure-resource-graph-arg-queries).

## Related Issues/Work Items

- None

## This PR fixes/adds/changes/removes

1. Fixes query result columns of VNET-1.

### Breaking Changes

- None

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
- [ ] Ensured PR tests are passing
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries and/or scripts
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)

## Evidence

![image](https://github.com/Azure/Azure-Proactive-Resiliency-Library/assets/1618784/5e764470-0246-4ed7-b66c-edc7434d30d3)
