### PR TITLE
Fix query result column for VNET-2

### DIFF
--- a/docs/content/services/networking/virtual-networks/code/vnet-2/vnet-2.kql
+++ b/docs/content/services/networking/virtual-networks/code/vnet-2/vnet-2.kql
@@ -3,4 +3,4 @@
 resources
 | where type =~ 'Microsoft.Network/virtualNetworks'
 | where isnull(properties.enableDdosProtection) or properties.enableDdosProtection contains "false"
-| project recommendationId = "vnet-2", name, id, tags, DdosProtection=properties.enableDdosProtection
+| project recommendationId = "vnet-2", name, id, tags, param1 = strcat("EnableDdosProtection: ", properties.enableDdosProtection)

--- a/docs/content/services/networking/virtual-networks/code/vnet-2/vnet-2.kql
+++ b/docs/content/services/networking/virtual-networks/code/vnet-2/vnet-2.kql
@@ -1,5 +1,5 @@
 // Azure Resource Graph Query
-// Find Subnets without NSG associated
+// Find virtual networks without DDoS Protection
 resources
 | where type =~ 'Microsoft.Network/virtualNetworks'
 | where isnull(properties.enableDdosProtection) or properties.enableDdosProtection contains "false"


### PR DESCRIPTION
# Overview/Summary

Fixed a query result column of VNET-2 to align [the Azure Resource Graph query standards](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing/#azure-resource-graph-arg-queries).

## Related Issues/Work Items

- None

## This PR fixes/adds/changes/removes

1. Fixes a query result column of VNET-2.
2. Fixes the description of the ARG query.

### Breaking Changes

- None

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
- [ ] Ensured PR tests are passing
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries and/or scripts
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)

## Evidence

![image](https://github.com/Azure/Azure-Proactive-Resiliency-Library/assets/1618784/415c2465-a9bc-4b21-b9fe-20728e38099d)
