### PR TITLE
Add params to VM-16

### DIFF
--- a/docs/content/services/compute/virtual-machines/code/vm-16/vm-16.kql
+++ b/docs/content/services/compute/virtual-machines/code/vm-16/vm-16.kql
@@ -18,5 +18,7 @@ resources
     | project diskId = tolower(coalesce(osDiskId, dataDiskId)), vmName = coalesce(osDiskVmName, dataDiskVmName)
     )
     on $left.lowerCaseId == $right.diskId
-| project recommendationId = "vm-16", name, id, tags, param1 = strcat("DiskState: ", properties.diskState), param2 = iif(isempty(vmName), "VMName: n/a", strcat("VMName: ", vmName))
+| summarize vmNames = make_set(vmName) by name, id, tostring(tags), diskState = tostring(properties.diskState)
+| extend param1 = strcat("DiskState: ", diskState), param2 = iif(isempty(vmNames[0]), "VMName: n/a", strcat("VMName: ", strcat_array(vmNames, ", ")))
+| project recommendationId = "vm-16", name, id, tags, param1, param2
 | order by id asc

--- a/docs/content/services/compute/virtual-machines/code/vm-16/vm-16.kql
+++ b/docs/content/services/compute/virtual-machines/code/vm-16/vm-16.kql
@@ -1,7 +1,22 @@
 // Azure Resource Graph Query
 // Find all Disks configured to be Shared. This is not an indication of an issue, but if a disk with this configuration is assigned to two or more VMs without a proper disk control mechanism (like a WSFC) it can lead to data loss
-Resources
+resources
 | where type =~ 'Microsoft.Compute/disks'
 | where isnotnull(properties.maxShares)
-| project recommendationId = "vm-16", name, id, tags
+| extend lowerCaseId = tolower(id)
+| join kind = leftouter (
+    resources
+    | where type =~ 'Microsoft.Compute/virtualMachines'
+    | project osDiskVmName = name, osDiskId = tostring(properties.storageProfile.osDisk.managedDisk.id)
+    | join kind = fullouter (
+        resources
+        | where type =~ 'Microsoft.Compute/virtualMachines'
+        | mv-expand dataDisks = properties.storageProfile.dataDisks
+        | project dataDiskVmName = name, dataDiskId = tostring(dataDisks.managedDisk.id)
+        )
+        on $left.osDiskId == $right.dataDiskId
+    | project diskId = tolower(coalesce(osDiskId, dataDiskId)), vmName = coalesce(osDiskVmName, dataDiskVmName)
+    )
+    on $left.lowerCaseId == $right.diskId
+| project recommendationId = "vm-16", name, id, tags, param1 = strcat("DiskState: ", properties.diskState), param2 = iif(isempty(vmName), "VMName: n/a", strcat("VMName: ", vmName))
 | order by id asc

--- a/docs/content/services/compute/virtual-machines/code/vm-16/vm-16.kql
+++ b/docs/content/services/compute/virtual-machines/code/vm-16/vm-16.kql
@@ -3,22 +3,22 @@
 resources
 | where type =~ 'Microsoft.Compute/disks'
 | where isnotnull(properties.maxShares)
-| extend lowerCaseId = tolower(id)
+| project id, name, tags, lowerCaseDiskId = tolower(id), diskState = tostring(properties.diskState)
 | join kind = leftouter (
     resources
     | where type =~ 'Microsoft.Compute/virtualMachines'
-    | project osDiskVmName = name, osDiskId = tostring(properties.storageProfile.osDisk.managedDisk.id)
+    | project osDiskVmName = name, lowerCaseOsDiskId = tolower(properties.storageProfile.osDisk.managedDisk.id)
     | join kind = fullouter (
         resources
         | where type =~ 'Microsoft.Compute/virtualMachines'
         | mv-expand dataDisks = properties.storageProfile.dataDisks
-        | project dataDiskVmName = name, dataDiskId = tostring(dataDisks.managedDisk.id)
+        | project dataDiskVmName = name, lowerCaseDataDiskId = tolower(dataDisks.managedDisk.id)
         )
-        on $left.osDiskId == $right.dataDiskId
-    | project diskId = tolower(coalesce(osDiskId, dataDiskId)), vmName = coalesce(osDiskVmName, dataDiskVmName)
+        on $left.lowerCaseOsDiskId == $right.lowerCaseDataDiskId
+    | project lowerCaseDiskId = coalesce(lowerCaseOsDiskId, lowerCaseDataDiskId), vmName = coalesce(osDiskVmName, dataDiskVmName)
     )
-    on $left.lowerCaseId == $right.diskId
-| summarize vmNames = make_set(vmName) by name, id, tostring(tags), diskState = tostring(properties.diskState)
+    on lowerCaseDiskId
+| summarize vmNames = make_set(vmName) by name, id, tostring(tags), diskState
 | extend param1 = strcat("DiskState: ", diskState), param2 = iif(isempty(vmNames[0]), "VMName: n/a", strcat("VMName: ", strcat_array(vmNames, ", ")))
 | project recommendationId = "vm-16", name, id, tags, param1, param2
 | order by id asc


### PR DESCRIPTION
# Overview/Summary

Added two params to the query result of VM-16. `param1` is disk state, `param2` is the VM name that manages the disk.

## Related Issues/Work Items

- None

## This PR fixes/adds/changes/removes

1. Adds two params to the query result of VM-16. `param1` is disk state, `param2` is the VM name that manages the disk.

### Breaking Changes

- None

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
- [x] Ensured PR tests are passing
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries and/or scripts
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)

## Evidence

![image](https://github.com/Azure/Azure-Proactive-Resiliency-Library/assets/1618784/6a465dd6-694d-4f84-a6b7-5ca9cb45ac31)

