### PR TITLE
Improve VM-18 query

### DIFF
--- a/docs/content/services/compute/virtual-machines/code/vm-18/vm-18.kql
+++ b/docs/content/services/compute/virtual-machines/code/vm-18/vm-18.kql
@@ -1,8 +1,6 @@
 // Azure Resource Graph Query
 // Find all VMs in "NonCompliant" state with Azure Policies
 PolicyResources
-| where type =~ 'microsoft.policyinsights/policystates'
-| where properties.complianceState == 'NonCompliant'
-| extend vmResourceId = properties.resourceId, vmresourceType = properties.resourceType, PolicyAssignmentName = properties.policyAssignmentName
-| where vmresourceType == 'Microsoft.Compute/virtualMachines'
+| where type =~ "Microsoft.PolicyInsights/policyStates" and properties.resourceType =~ "Microsoft.Compute/virtualMachines" and properties.complianceState =~ "NonCompliant"
+| extend vmResourceId = properties.resourceId, PolicyAssignmentName = properties.policyAssignmentName
 | project recommendationId = "vm-18", name = tostring(split(tostring(properties.resourceId), '/')[8]), id=vmResourceId, tags, param1 = strcat ("Policyname: ", PolicyAssignmentName)

--- a/docs/content/services/compute/virtual-machines/code/vm-18/vm-18.kql
+++ b/docs/content/services/compute/virtual-machines/code/vm-18/vm-18.kql
@@ -2,5 +2,26 @@
 // Find all VMs in "NonCompliant" state with Azure Policies
 PolicyResources
 | where type =~ "Microsoft.PolicyInsights/policyStates" and properties.resourceType =~ "Microsoft.Compute/virtualMachines" and properties.complianceState =~ "NonCompliant"
-| extend vmResourceId = tostring(properties.resourceId), policyAssignmentName = properties.policyAssignmentName
-| project recommendationId = "vm-18", name = split(vmResourceId, '/')[8], id = vmResourceId, tags, param1 = strcat("PolicyAssignmentName: ", policyAssignmentName)
+| project
+    policyAssignmentName = properties.policyAssignmentName,
+    policyDefinitionName = properties.policyDefinitionName,
+    lowerCasePolicyDefinitionIdOfPolicyState = tolower(properties.policyDefinitionId),
+    lowerCaseVmIdOfPolicyState = tolower(properties.resourceId)
+| join kind = leftouter (
+    PolicyResources
+    | where type =~ "Microsoft.Authorization/policyDefinitions"
+    | project lowerCasePolicyDefinitionId = tolower(id), policyDefinitionDisplayName = properties.displayName
+    )
+    on $left.lowerCasePolicyDefinitionIdOfPolicyState == $right.lowerCasePolicyDefinitionId
+| project policyAssignmentName, policyDefinitionName, policyDefinitionDisplayName, lowerCaseVmIdOfPolicyState
+| join kind = leftouter (
+    Resources
+    | where type =~ "Microsoft.Compute/virtualMachines"
+    | project vmName = name, vmId = id, vmTags = tags, lowerCaseVmId = tolower(id)
+    )
+    on $left.lowerCaseVmIdOfPolicyState == $right.lowerCaseVmId
+| extend
+    param1 = strcat("AssignmentName: ", policyAssignmentName),
+    param2 = strcat("DefinitionName: ", policyDefinitionDisplayName),  // Align to Azure portal's term.
+    param3 = strcat("DefinitionID: ", policyDefinitionName)            // Align to Azure portal's term.
+| project recommendationId = "vm-18", name = vmName, id = vmId, tags = vmTags, param1, param2, param3

--- a/docs/content/services/compute/virtual-machines/code/vm-18/vm-18.kql
+++ b/docs/content/services/compute/virtual-machines/code/vm-18/vm-18.kql
@@ -5,4 +5,4 @@ PolicyResources
 | where properties.complianceState == 'NonCompliant'
 | extend vmResourceId = properties.resourceId, vmresourceType = properties.resourceType, PolicyAssignmentName = properties.policyAssignmentName
 | where vmresourceType == 'Microsoft.Compute/virtualMachines'
-| project recommendationId = "vm-18", name = tostring(split(tostring(properties.resourceId), '/')[8]), id=vmResourceId, tags, param1 = strcat ("Policyname: ", name)
+| project recommendationId = "vm-18", name = tostring(split(tostring(properties.resourceId), '/')[8]), id=vmResourceId, tags, param1 = strcat ("Policyname: ", PolicyAssignmentName)

--- a/docs/content/services/compute/virtual-machines/code/vm-18/vm-18.kql
+++ b/docs/content/services/compute/virtual-machines/code/vm-18/vm-18.kql
@@ -2,5 +2,5 @@
 // Find all VMs in "NonCompliant" state with Azure Policies
 PolicyResources
 | where type =~ "Microsoft.PolicyInsights/policyStates" and properties.resourceType =~ "Microsoft.Compute/virtualMachines" and properties.complianceState =~ "NonCompliant"
-| extend vmResourceId = tostring(properties.resourceId), PolicyAssignmentName = properties.policyAssignmentName
-| project recommendationId = "vm-18", name = split(vmResourceId, '/')[8], id = vmResourceId, tags, param1 = strcat ("Policyname: ", PolicyAssignmentName)
+| extend vmResourceId = tostring(properties.resourceId), policyAssignmentName = properties.policyAssignmentName
+| project recommendationId = "vm-18", name = split(vmResourceId, '/')[8], id = vmResourceId, tags, param1 = strcat("PolicyAssignmentName: ", policyAssignmentName)

--- a/docs/content/services/compute/virtual-machines/code/vm-18/vm-18.kql
+++ b/docs/content/services/compute/virtual-machines/code/vm-18/vm-18.kql
@@ -2,5 +2,5 @@
 // Find all VMs in "NonCompliant" state with Azure Policies
 PolicyResources
 | where type =~ "Microsoft.PolicyInsights/policyStates" and properties.resourceType =~ "Microsoft.Compute/virtualMachines" and properties.complianceState =~ "NonCompliant"
-| extend vmResourceId = properties.resourceId, PolicyAssignmentName = properties.policyAssignmentName
-| project recommendationId = "vm-18", name = tostring(split(tostring(properties.resourceId), '/')[8]), id=vmResourceId, tags, param1 = strcat ("Policyname: ", PolicyAssignmentName)
+| extend vmResourceId = tostring(properties.resourceId), PolicyAssignmentName = properties.policyAssignmentName
+| project recommendationId = "vm-18", name = split(vmResourceId, '/')[8], id = vmResourceId, tags, param1 = strcat ("Policyname: ", PolicyAssignmentName)


### PR DESCRIPTION
# Overview/Summary

Improved the VM-18 query.

## Related Issues/Work Items

- #194
- #195

## This PR fixes/adds/changes/removes

1. Changes `param1` value to `policyAssignmentName` from `name`. (#194)
2. Aggregates "where" operators based on [Best practices for Kusto Query Language queries](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/best-practices).
3. Adds policy definition name and ID as params (`param2`, `param3`).
4. Fixes the `tags` column in the result (#195) 

### Breaking Changes

- None

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
- [x] Ensured PR tests are passing
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries and/or scripts
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)

## Evidence

![image](https://github.com/Azure/Azure-Proactive-Resiliency-Library/assets/1618784/2cb572fe-256c-4b3b-a3b9-d656da5ac306)
