### PR TITLE
Fix non-standard "under-development" lines

### DIFF
--- a/docs/content/services/monitoring/log-analytics/code/log-1/log-1.kql
+++ b/docs/content/services/monitoring/log-analytics/code/log-1/log-1.kql
@@ -1,1 +1,1 @@
-under-development
+// under-development

--- a/docs/content/services/monitoring/log-analytics/code/log-3/log-3.kql
+++ b/docs/content/services/monitoring/log-analytics/code/log-3/log-3.kql
@@ -1,1 +1,1 @@
-under-development
+// under-development

--- a/docs/content/services/monitoring/log-analytics/code/log-4/log-4.kql
+++ b/docs/content/services/monitoring/log-analytics/code/log-4/log-4.kql
@@ -1,1 +1,1 @@
-under-development
+// under-development

--- a/docs/content/services/networking/firewall/code/afw-6/afw-6.kql
+++ b/docs/content/services/networking/firewall/code/afw-6/afw-6.kql
@@ -1,1 +1,1 @@
-//under development
+// under-development


### PR DESCRIPTION
# Overview/Summary

Fixed `under-development` lines those are not align to [Automation Standards for Recommendations](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing/#automation-standards-for-recommendations).

## Related Issues/Work Items

- None

## This PR fixes/adds/changes/removes

1. Fixes non-standard `under-development` lines.

### Breaking Changes

- None

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
- [ ] Ensured PR tests are passing
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries and/or scripts
    - Build succeeded and showing contents correctly with local server (`hugo server -D`). 
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
