### PR TITLE
Change the recommendation title wording of diagnostics settings

### DIFF
--- a/docs/content/services/compute/virtual-machines/_index.md
+++ b/docs/content/services/compute/virtual-machines/_index.md
@@ -34,7 +34,7 @@ The presented resiliency recommendations in this guidance include Virtual Machin
 | [VM-18 - Virtual Machine is not compliant with Azure Policies](#vm-18---ensure-that-your-vms-are-compliant-with-azure-policies)                                                                                                    |  Low   | Verified |         Yes         |
 | [VM-19 - Enable disk encryption, Enable data at rest encryption by default](#vm-19---enable-disk-encryption-and-data-at-rest-encryption-by-default)                                                                                | Medium | Verified |         Yes          |
 | [VM-20 - Enable Insights to get more visibility into the health and performance of your virtual machine](#vm-20---enable-vm-insights)                                                                                              |  Low   | Verified |         Yes          |
-| [VM-21 - Diagnostic Settings should be configured for all Azure Resources](#vm-21---configure-diagnostic-settings-for-all-azure-resources)                                                                                         |  Low   | Preview  |         Yes         |
+| [VM-21 - Diagnostic Settings should be configured for all Azure Virtual Machines](#vm-21---configure-diagnostic-settings-for-all-azure-virtual-machines)                                                                                         |  Low   | Preview  |         Yes         |
 | [VM-22 - Use maintenance configurations for the Virtual Machine](#vm-22---use-maintenance-configurations-for-the-vms) | High | Preview | Yes |
 {{< /table >}}
 
@@ -561,7 +561,7 @@ VM insights monitors the performance and health of your virtual machines and vir
 
 <br><br>
 
-### VM-21 - Configure diagnostic settings for all Azure resources
+### VM-21 - Configure diagnostic settings for all Azure Virtual Machines
 
 **Category: Monitoring**
 

--- a/docs/content/services/compute/virtual-machines/_index.md
+++ b/docs/content/services/compute/virtual-machines/_index.md
@@ -34,7 +34,7 @@ The presented resiliency recommendations in this guidance include Virtual Machin
 | [VM-18 - Virtual Machine is not compliant with Azure Policies](#vm-18---ensure-that-your-vms-are-compliant-with-azure-policies)                                                                                                    |  Low   | Verified |         Yes         |
 | [VM-19 - Enable disk encryption, Enable data at rest encryption by default](#vm-19---enable-disk-encryption-and-data-at-rest-encryption-by-default)                                                                                | Medium | Verified |         Yes          |
 | [VM-20 - Enable Insights to get more visibility into the health and performance of your virtual machine](#vm-20---enable-vm-insights)                                                                                              |  Low   | Verified |         Yes          |
-| [VM-21 - Diagnostic Settings should be configured for all Azure Virtual Machines](#vm-21---configure-diagnostic-settings-for-all-azure-virtual-machines)                                                                                         |  Low   | Preview  |         Yes         |
+| [VM-21 - Configure diagnostic settings for all Azure Virtual Machines](#vm-21---configure-diagnostic-settings-for-all-azure-virtual-machines)                                                                                         |  Low   | Preview  |         Yes         |
 | [VM-22 - Use maintenance configurations for the Virtual Machine](#vm-22---use-maintenance-configurations-for-the-vms) | High | Preview | Yes |
 {{< /table >}}
 

--- a/docs/content/services/container/container-registry/_index.md
+++ b/docs/content/services/container/container-registry/_index.md
@@ -23,7 +23,7 @@ The presented resiliency recommendations in this guidance include Container Regi
 | [CR-7 - Manage registry size](#cr-7---manage-registry-size)                                                                                                                                                                        | Medium | Preview |         No         |
 | [CR-8 - Disable anonymous pull access](#cr-8---disable-anonymous-pull-access)                                                                                                                                                      | Medium | Preview |         Yes         |
 | [CR-9 - Use an Azure managed identity to authenticate to an Azure container registry](#cr-9---use-an-azure-managed-identity-to-authenticate-to-an-azure-container-registry)                                                        | Medium | Preview |         No         |
-| [CR-10 - Configure Diagnostic Settings for all Azure Resources](#cr-10---configure-diagnostic-settings-for-all-azure-resources)                                                                                                    | Medium | Preview |         No         |
+| [CR-10 - Configure Diagnostic Settings for all Azure Container Registries](#cr-10---configure-diagnostic-settings-for-all-azure-container-registries)                                                                                                    | Medium | Preview |         No         |
 | [CR-11 - Monitor Azure Container Registry with Azure Monitor](#cr-11---monitor-azure-container-registry-with-azure-monitor)                                                                                                        | Medium | Preview |         No          |
 | [CR-12 - Enable soft delete policy](#cr-12---enable-soft-delete-policy)                                                                                                                                                            | Medium | Preview |         Yes
 {{< /table >}}
@@ -263,7 +263,7 @@ Use a managed identity for Azure resources to authenticate to an Azure container
 
 <br><br>
 
-### CR-10 - Configure Diagnostic Settings for all Azure Resources
+### CR-10 - Configure Diagnostic Settings for all Azure Container Registries
 
 **Category: Monitoring**
 

--- a/docs/content/services/integration/event-grid/_index.md
+++ b/docs/content/services/integration/event-grid/_index.md
@@ -14,7 +14,7 @@ The presented resiliency recommendations in this guidance include Event Grid and
 {{< table style="table-striped" >}}
 | Recommendation                                    |  Category                                                               |  Impact         |  State   | ARG Query Available |
 | :------------------------------------------------ | :---------------------------------------------------------------------: | :------:        | :------: | :-----------------: |
-| [EVG-1 - Configure Diagnostic Settings for all Azure Resources](#evg-1---configure-diagnostic-settings-for-all-azure-resources) | Monitoring | Low | Preview  |         No        |
+| [EVG-1 - Configure Diagnostic Settings for all Azure Event Grid resources](#evg-1---configure-diagnostic-settings-for-all-azure-event-grid-resources) | Monitoring | Low | Preview  |         No        |
 | [EVG-2 - Configure Dead-letter to save events that cannot be delivered](#evg-2---configure-dead-letter-to-save-events-that-cannot-be-delivered) | Automation          | Low | Preview |         No          |
 | [EVG-3 - Configure Private Endpoints](#evg-3---configure-private-endpoints) | Access & Security          | Low | Preview |         Yes          |
 {{< /table >}}
@@ -27,7 +27,7 @@ Definitions of states can be found [here]({{< ref "../../../_index.md#definition
 
 ## Recommendations Details
 
-### EVG-1 - Configure Diagnostic Settings for all Azure Resources
+### EVG-1 - Configure Diagnostic Settings for all Azure Event Grid resources
 
 **Category: Monitoring**
 

--- a/docs/content/services/networking/network-security-group/_index.md
+++ b/docs/content/services/networking/network-security-group/_index.md
@@ -14,7 +14,7 @@ The presented resiliency recommendations in this guidance include Network Securi
 {{< table style="table-striped" >}}
 | Recommendation                                                                                                                                                                |  Category         |  Impact   |  State     | ARG Query Available |
 | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :--------------:  | :------:  | :------:   | :-----------------: |
-| [NSG-1 - Configure Diagnostic Settings for all Azure Resources](#nsg-1---configure-diagnostic-settings-for-all-azure-resources)                                               | Monitoring        |  Medium   | Preview    |     No          |
+| [NSG-1 - Configure Diagnostic Settings for all network security groups](#nsg-1---configure-diagnostic-settings-for-all-network-security-groups)                                               | Monitoring        |  Medium   | Preview    |     No          |
 | [NSG-2 - Monitor changes in Network Security Groups with Azure Monitor](#nsg-2---monitor-changes-in-network-security-groups-with-azure-monitor)                               | Monitoring        |     Low   | Preview    |     Yes          |
 | [NSG-3 - Configure locks for Network Security Groups to avoid accidental changes and/or deletion](#nsg-3---configure-locks-for-network-security-groups-to-avoid-accidental-changes-andor-deletion)      | Governance        |     Low   | Preview    |     No          |
 | [NSG-4 - Configure NSG Flow Logs](#nsg-4---configure-nsg-flow-logs)                                                                     | Monitoring        |  Medium   | Preview    |     Yes         |
@@ -29,7 +29,7 @@ Definitions of states can be found [here]({{< ref "../../../_index.md#definition
 
 ## Recommendations Details
 
-### NSG-1 - Configure Diagnostic Settings for all Azure Resources
+### NSG-1 - Configure Diagnostic Settings for all network security groups
 
 **Category: Monitoring**
 

--- a/docs/content/services/storage/storage-Account/_index.md
+++ b/docs/content/services/storage/storage-Account/_index.md
@@ -23,7 +23,7 @@ The below table shows the list of resiliency recommendations for Storage Account
 |[ST-5 - Enable soft delete for recovery of data](#st-5---enable-soft-delete-for-recovery-of-data)                                                      |  Medium  | Preview  |         No          |
 |[ST-6 - Enable version for accidental modification and keep the number of versions below 1000](#st-6---enable-version-for-accidental-modification-and-keep-the-number-of-versions-below-1000) |  Medium  | Preview  |         No          |
 |[ST-7 - Enable point and time restore for containers for recovery](#st-7---enable-point-and-time-restore-for-containers-for-recovery)                  |   Low    | Preview  |         No          |
-|[ST-8 - Configure Diagnostic Settings for all Azure Resources](#st-8---configure-diagnostic-settings-for-all-azure-resources)                          |   Low    | Preview  |         No          |
+|[ST-8 - Configure Diagnostic Settings for all storage accounts](#st-8---configure-diagnostic-settings-for-all-storage-accounts)                          |   Low    | Preview  |         No          |
 
 {{< /table >}}
 
@@ -210,7 +210,7 @@ Point and time restore support general purpose v2 account in standard performanc
 
 <br><br>
 
-### ST-8 - Configure Diagnostic Settings for all Azure Resources
+### ST-8 - Configure Diagnostic Settings for all storage accounts
 
 **Category: Monitoring**
 


### PR DESCRIPTION
# Overview/Summary

Changed the recommendation title wording of diagnostics settings from `for all Azure Resources` to specific resource type.

## Related Issues/Work Items

- #167

## This PR fixes/adds/changes/removes

1. Changes the recommendation title wording of diagnostics settings from `for all Azure Resources` to specific resource type.
2. Changes the recommendation title of VM-21 to match with other resource's recommendation title of the same diagnostics settings.

### Breaking Changes

- None

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
- [x] Ensured PR tests are passing
    - Document building is fine in my local environment.
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries and/or scripts
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
