### PR TITLE
(fix) add missing aks to service list

### DIFF
--- a/services-abbreviations.csv
+++ b/services-abbreviations.csv
@@ -5,6 +5,7 @@ microsoft.web/serverfarms,App Service Plan,asp
 microsoft.virtualmachineimages/imagetemplates,Image template,it
 microsoft.compute/virtualmachines,Virtual machine,vm
 microsoft.compute/virtualmachinescalesets,Virtual machine scale set,vmss
+microsoft.containerservice/managedclusters,Kubernetes Service,aks
 microsoft.containerregistry/registries,Container registry,cr
 microsoft.documentdb/databaseaccounts/sqldatabases,Azure Cosmos DB database,cosmos
 microsoft.sql/servers/databases,Azure SQL database,sqldb


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

The queries for AKS are not getting executed, as the service is missing in the service list.

## Related Issues/Work Items

None

## This PR fixes/adds/changes/removes

1. execute the queries for AKS as well

### Breaking Changes

None

## As part of this Pull Request I have

- [X] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing) and ensured this PR is compliant with the guide
- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
- [x] Ensured PR tests are passing
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries and/or scripts
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
