### PR TITLE
Added AVD recommendation 9

### DIFF
--- a/docs/content/services/specialized-workloads/azure-virtual-desktop/_index.md
+++ b/docs/content/services/specialized-workloads/azure-virtual-desktop/_index.md
@@ -257,9 +257,9 @@ To handle a large number of users, consider scaling horizontally by creating mul
 
 It is important to ensure the redundancy of our user profiles when using FSLogix. When using FSLogix with AVD, it is deployed on a file share in a storage account. Data in an Azure Storage account is always replicated three times in the primary region. Below are the options for how your data is replicated in the primary or paired region:
 LRS for least expensive replication (not recommended for apps with high availability and durability).
-- LRS provides eleven 9 durability and replicates 3 time in a single physical location.
-- ZRS is recommended for apps requiring high availability across zones. ZRS provides twelve 9s durability. Replicated across 3 availability zones
-- GRS replicate additional 3 copies to secondary region and provides sixteen 9s availability.
+- LRS provides eleven 9s durability and replicates three time in a single physical location.
+- ZRS is recommended for apps requiring high availability across zones. ZRS provides twelve 9s durability. Replicated across three availability zones
+- GRS replicates an additional three copies to secondary region and provides sixteen 9s durability.
 - GZRS provides both high availability and redundancy across geo replication. It provides sixteen 9s durability over a given year.
 
 Generally, it is recommended to store your data as secure and redundant as possible.

--- a/docs/content/services/specialized-workloads/azure-virtual-desktop/_index.md
+++ b/docs/content/services/specialized-workloads/azure-virtual-desktop/_index.md
@@ -22,6 +22,7 @@ The presented resiliency recommendations in this guidance include Azure Virtual 
 | [AVD-6 Implement a Multi-Region BCDR Plan](#avd-6---implement-a-multi-region-bcdr-plan)  | Medium |  Backup | Preview |       No        |
 | [AVD-7 Store Golden Image Redundantly for Disaster Recovery](#avd-7---store-golden-image-redundantly-for-disaster-recovery)  | Low |  Backup | Preview |       No        |
 | [AVD-8 Capacity Planning for AVD Resources](#avd-8---capacity-planning-for-avd-resources)  | Low |  Compute | Preview |       No        |
+| [AVD-9 Ensure that FSLogix Storage Account is Redundant](#avd-9---ensure-that-fslogix-storage-account-is-redundant)  | High |  Reliability/Storage | Preview |       No        |
 
 {{< /table >}}
 
@@ -241,6 +242,39 @@ To handle a large number of users, consider scaling horizontally by creating mul
 {{< collapse title="Show/Hide Query/Script" >}}
 
 {{< code lang="sql" file="code/avd-8/avd-8.kql" >}} {{< /code >}}
+
+{{< /collapse >}}
+
+<br><br>
+
+### AVD-9 - Ensure that FSLogix Storage Account is Redundant
+
+**Category: Reliability / Storage**
+
+**Impact: High**
+
+**Recommendation/Guidance**
+
+It is important to ensure the redundancy of our user profiles when using FSLogix. When using FSLogix with AVD, it is deployed on a file share in a storage account. Data in an Azure Storage account is always replicated three times in the primary region. Below are the options for how your data is replicated in the primary or paired region:
+LRS for least expensive replication (not recommended for apps with high availability and durability).
+- LRS provides eleven 9 durability and replicates 3 time in a single physical location.
+- ZRS is recommended for apps requiring high availability across zones. ZRS provides twelve 9s durability. Replicated across 3 availability zones
+- GRS replicate additional 3 copies to secondary region and provides sixteen 9s availability.
+- GZRS provides both high availability and redundancy across geo replication. It provides sixteen 9s durability over a given year.
+
+Generally, it is recommended to store your data as secure and redundant as possible.
+
+
+**Resources**
+
+- [Learn More](https://learn.microsoft.com/en-us/azure/well-architected/azure-virtual-desktop/storage#user-profiles)
+
+
+**Resource Graph Query/Scripts**
+
+{{< collapse title="Show/Hide Query/Script" >}}
+
+{{< code lang="sql" file="code/avd-9/avd-9.kql" >}} {{< /code >}}
 
 {{< /collapse >}}
 

--- a/docs/content/services/specialized-workloads/azure-virtual-desktop/code/avd-9/avd-9.kql
+++ b/docs/content/services/specialized-workloads/azure-virtual-desktop/code/avd-9/avd-9.kql
@@ -1,0 +1,1 @@
+// under-development


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

I added a 9th recommendation per request of the PG and Pm. I thought there may be push back because it is on a storage account and we have a storage account section bu they felt like FSLogix needed its own recommendation.  I agree with the AVd team and this this is important. Happy to discuss further if you fell like it does not belong in this section. 

## Related Issues/Work Items

[Replace this with a list of related GitHub Issues and/or ADO Work Items (Internal Only)](https://dev.azure.com/CSUSolEng/Accelerator%20-%20AVD/_workitems/edit/32444)

- To associate a GitHub Issue, use a [key word](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) preceded with the GitHub issue number.
- To associate an ADO Work Item, use the key word `AB#` succeeded with the [ADO Work Item ID](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

## This PR adds

1. AVD 9

### Breaking Changes

1. NA

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
- [x] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries and/or scripts
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
