### PR TITLE
Updated the condition for classic backup vaults and case insensitive

### DIFF
--- a/docs/content/services/migration/azure-backup/code/bk-1/bk-1.kql
+++ b/docs/content/services/migration/azure-backup/code/bk-1/bk-1.kql
@@ -4,5 +4,5 @@ Resources
 | extend monitoringSettings = parse_json(properties).monitoringSettings
 | extend isUsingClassicAlerts = case(isnull(monitoringSettings), 'Enabled',monitoringSettings.classicAlertSettings.alertsForCriticalOperations)
 | extend isUsingJobsAlerts = case(isnull(monitoringSettings), 'Enabled', monitoringSettings.azureMonitorAlertSettings.alertsForAllJobFailures)
-| where isUsingClassicAlerts == 'Enabled'
+| where isUsingClassicAlerts !~ 'Disbled'
 | project recommendationId = "bk-1",name,id,tags,param1=strcat("isUsingClassicAlerts: ", isUsingClassicAlerts),param2=strcat("isUsingJobsAlerts: ", isUsingJobsAlerts)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Based on PG feedback: 

Instead of | where isUsingClassicAlerts == 'Enabled'' it is better to make it "IsUsingClassicAlerts!="Disabled". This is because sometimes this value could be null as well, and null also means that classic alerts is enabled for that vault (due to various legacy reasons).
## Related Issues/Work Items

N/A

## This PR fixes/adds/changes/removes

1. Instead of | where isUsingClassicAlerts == 'Enabled'' it is better to make it "IsUsingClassicAlerts!="Disabled"

### Breaking Changes

1. N/A

## As part of this Pull Request I have

- [ ] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing) and ensured this PR is compliant with the guide
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries and/or scripts
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
