### PR TITLE
Vnet 1 fix

### DIFF
--- a/docs/content/services/networking/virtual-networks/_index.md
+++ b/docs/content/services/networking/virtual-networks/_index.md
@@ -37,12 +37,14 @@ Definitions of states can be found [here]({{< ref "../../../_index.md#definition
 
 **Guidance**
 
-Network security groups: Network security groups and application security groups can contain multiple inbound and outbound security rules that enable you to filter traffic to and from resources by source and destination IP address, port, and protocol. NSG's provide a security layer on Subnet level. Note that GatewaySubnet is excluded because applying NSG on GatewaySubnet is not supported.
+Network security groups: Network security groups and application security groups can contain multiple inbound and outbound security rules that enable you to filter traffic to and from resources by source and destination IP address, port, and protocol. NSG's provide a security layer on Subnet level. Note that the following subnets are excluded(ignored) because applying NSG on these subnets is not supported: GatewaySubnet, AzureFirewallSubnet, AzureFirewallManagementSubnet, RouteServerSubnet.
 
 **Resources**
 
 - [Azure Virtual Network - Concepts and best practices | Microsoft Learn](https://learn.microsoft.com/azure/virtual-network/concepts-and-best-practices)
 - [GatewaySUbnet](https://learn.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-about-vpn-gateway-settings#gwsub)
+- [Can I associate a network security group (NSG) to the RouteServerSubnet?](https://learn.microsoft.com/en-us/azure/route-server/route-server-faq#can-i-associate-a-network-security-group-nsg-to-the-routeserversubnet)
+- [Are Network Security Groups (NSGs) supported on the AzureFirewallSubnet?](https://learn.microsoft.com/en-us/azure/firewall/firewall-faq#are-network-security-groups--nsgs--supported-on-the-azurefirewallsubnet)
 
 **Resource Graph Query/Scripts**
 

--- a/docs/content/services/networking/virtual-networks/_index.md
+++ b/docs/content/services/networking/virtual-networks/_index.md
@@ -37,11 +37,12 @@ Definitions of states can be found [here]({{< ref "../../../_index.md#definition
 
 **Guidance**
 
-Network security groups: Network security groups and application security groups can contain multiple inbound and outbound security rules that enable you to filter traffic to and from resources by source and destination IP address, port, and protocol. NSG's provide a security layer on Subnet level.
+Network security groups: Network security groups and application security groups can contain multiple inbound and outbound security rules that enable you to filter traffic to and from resources by source and destination IP address, port, and protocol. NSG's provide a security layer on Subnet level. Note that GatewaySubnet is excluded because applying NSG on GatewaySubnet is not supported.
 
 **Resources**
 
 - [Azure Virtual Network - Concepts and best practices | Microsoft Learn](https://learn.microsoft.com/azure/virtual-network/concepts-and-best-practices)
+- [GatewaySUbnet](https://learn.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-about-vpn-gateway-settings#gwsub)
 
 **Resource Graph Query/Scripts**
 

--- a/docs/content/services/networking/virtual-networks/code/vnet-1/vnet-1.kql
+++ b/docs/content/services/networking/virtual-networks/code/vnet-1/vnet-1.kql
@@ -4,5 +4,5 @@ resources
 | where type =~ 'Microsoft.Network/virtualnetworks'
 | mv-expand subnets = properties.subnets
 | extend sn = string_size(subnets.properties.networkSecurityGroup)
-| where sn == 0
+| where sn == 0 and subnets.name != "GatewaySubnet"
 | project recommendationId = "vnet-1", name, id, tags, param1 = strcat("SubnetName: ", subnets.name), param2 = "NSG: False"

--- a/docs/content/services/networking/virtual-networks/code/vnet-1/vnet-1.kql
+++ b/docs/content/services/networking/virtual-networks/code/vnet-1/vnet-1.kql
@@ -4,5 +4,5 @@ resources
 | where type =~ 'Microsoft.Network/virtualnetworks'
 | mv-expand subnets = properties.subnets
 | extend sn = string_size(subnets.properties.networkSecurityGroup)
-| where sn == 0 and subnets.name != "GatewaySubnet"
+| where sn == 0 and subnets.name !in ("GatewaySubnet", "AzureFirewallSubnet", "AzureFirewallManagementSubnet", "RouteServerSubnet")
 | project recommendationId = "vnet-1", name, id, tags, param1 = strcat("SubnetName: ", subnets.name), param2 = "NSG: False"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

vnet-1 KQL needs to exclude GatewaySubnet as applying NSG on GatewaySubnet is not supported.
[GatewaySubnet](https://learn.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-about-vpn-gateway-settings#gwsub)

## Related Issues/Work Items

#256 

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
- [x] Ensured PR tests are passing
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries and/or scripts
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
