### PR TITLE
Closes #279 (Metadata for Powershell scripts indicates sql instead of powershell like all other Powershell scripts)

### DIFF
--- a/docs/content/services/integration/event-grid/_index.md
+++ b/docs/content/services/integration/event-grid/_index.md
@@ -45,7 +45,7 @@ Enabling diagnostic settings allow you to capture and view diagnostic informatio
 
 {{< collapse title="Show/Hide Query/Script" >}}
 
-{{< code lang="sql" file="code/evg-1/evg-1.ps1" >}} {{< /code >}}
+{{< code lang="powershell" file="code/evg-1/evg-1.ps1" >}} {{< /code >}}
 
 {{< /collapse >}}
 
@@ -69,7 +69,7 @@ When Event Grid can't deliver an event within a certain time period or after try
 
 {{< collapse title="Show/Hide Query/Script" >}}
 
-{{< code lang="sql" file="code/evg-2/evg-2.ps1" >}} {{< /code >}}
+{{< code lang="powershell" file="code/evg-2/evg-2.ps1" >}} {{< /code >}}
 
 {{< /collapse >}}
 


### PR DESCRIPTION
# Overview/Summary

Metadata for Powershell scripts indicates `sql` instead of `powershell` like all other Powershell scripts.

## Related Issues/Work Items

Closes #279 

### Breaking Changes

n.a.

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
- [x] Ensured PR tests are passing
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries and/or scripts
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
