### PR TITLE
Lowering weight of privacy page

### DIFF
--- a/docs/content/Privacy/_index.md
+++ b/docs/content/Privacy/_index.md
@@ -1,7 +1,7 @@
 +++
 title = "Privacy"
 description = "This Privacy Policy outlines how we collect and use your data when you interact with this website."
-weight = 1
+weight = 4
 +++
 
 We partner with Microsoft Clarity to capture how you use and interact with our website through behavioral metrics, heatmaps, and session replay to improve the content and usage of the website. Website usage data is captured using first and third-party cookies and other tracking technologies and is used for site optimization. For more information about how Microsoft collects and uses your data, visit the Microsoft Privacy Statement.


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Lowering weight of Privacy page to be on bottom of navigation pane.

## Related Issues/Work Items

Replace this with a list of related GitHub Issues and/or ADO Work Items (Internal Only)

N/A

## This PR fixes/adds/changes/removes

1. Lowering weight of Privacy page to be on bottom of navigation pane.

### Breaking Changes

None

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
- [x] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries and/or scripts
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
