### PR TITLE
Resourcegroup

### DIFF
--- a/docs/content/services/management/resource-group/_index.md
+++ b/docs/content/services/management/resource-group/_index.md
@@ -1,0 +1,50 @@
++++
+title = "Resource Groups"
+description = "Best practices and resiliency recommendations for Resource Groups and associated resources and settings."
+date = "2/22/24"
+author = "edknox"
+msAuthor = "edknox"
+draft = false
++++
+
+The presented resiliency recommendations in this guidance include Resource Groups and its associated settings.
+
+## Summary of Recommendations
+
+{{< table style="table-striped" >}}
+| Recommendation                                                                                                                                                        |  Category  | Impact |  State  | ARG Query Available |
+|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------|:----------:|:------:|:-------:|:-------------------:|
+| [RG-1 - Resource group location alignment](#rg-1---resource-group-location-alignment) | Disaster Recovery | High | Preview |         Yes         |
+{{< /table >}}
+
+{{< alert style="info" >}}
+
+Definitions of states can be found [here]({{< ref "../../../_index.md#definitions-of-terms-used-in-aprl">}})
+
+{{< /alert >}}
+
+## Recommendations Details
+
+### RG-1 - Resource group location alignment
+
+**Category: Disaster Recovery**
+
+**Impact: High**
+
+**Guidance**
+
+Ensure your resource locations match that of the containing resource group. This ensures that, in the event of a regional outage, you will still be able to manage your resource. ARM stores resource data for resources in a resource group and, if the region is unavailable, updates to this data could fail, making the resource effectively read-only.
+
+**Resources**
+
+- [Azure Resource Manager Overview](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/overview#resource-group-location-alignment)
+
+**Resource Graph Query/Scripts**
+
+{{< collapse title="Show/Hide Query/Script" >}}
+
+{{< code lang="sql" file="code/rg-1/rg-1.kql" >}} {{< /code >}}
+
+{{< /collapse >}}
+
+<br><br>

--- a/docs/content/services/management/resource-group/code/rg-1/rg-1.kql
+++ b/docs/content/services/management/resource-group/code/rg-1/rg-1.kql
@@ -1,12 +1,12 @@
 // Azure Resource Graph Query
 // Provides a list of Azure Resource Groups that have resources deployed in a region different than the Resource Group region
 resources
-| project id, resourceGroup, location
+| project id, name, tags, resourceGroup, location
 | where location != "global"                                                                                                          // exclude global resources
 | where resourceGroup != "networkwatcherrg"                                                                                           // exclude networkwatcherrg
 | where split(id, "/", 3)[0] =~ "resourceGroups"                                                                                      // resource is in a resource group
 | extend resourceGroupId = strcat_array(array_slice(split(id, "/"),0,4), "/")                                                         // create resource group resource id
 | join (resourcecontainers | project containerid=id, containerlocation=location ) on $left.resourceGroupId == $right.['containerid']  // join to resourcecontainers table
 | where  location != containerlocation
-| project recommendationId="mg-1", name, id, tags
+| project recommendationId="rg-1", name, id, tags
 | order by id asc

--- a/docs/content/services/management/resource-group/code/rg-1/rg-1.kql
+++ b/docs/content/services/management/resource-group/code/rg-1/rg-1.kql
@@ -1,0 +1,12 @@
+// Azure Resource Graph Query
+// Provides a list of Azure Resource Groups that have resources deployed in a region different than the Resource Group region
+resources
+| project id, resourceGroup, location
+| where location != "global"                                                                                                          // exclude global resources
+| where resourceGroup != "networkwatcherrg"                                                                                           // exclude networkwatcherrg
+| where split(id, "/", 3)[0] =~ "resourceGroups"                                                                                      // resource is in a resource group
+| extend resourceGroupId = strcat_array(array_slice(split(id, "/"),0,4), "/")                                                         // create resource group resource id
+| join (resourcecontainers | project containerid=id, containerlocation=location ) on $left.resourceGroupId == $right.['containerid']  // join to resourcecontainers table
+| where  location != containerlocation
+| project recommendationId="mg-1", name, id, tags
+| order by id asc

--- a/services-abbreviations.csv
+++ b/services-abbreviations.csv
@@ -52,3 +52,4 @@ microsoft.avs/privateclouds,Azure VMware Solution,avs
 microsoft.signalrservice/signalr,SignalR,sigr
 microsoft.web/sites,Web App,app
 microsoft.batch/batchaccounts,Batch Accounts,ba
+microsoft.resources/resourcegroups,Resource Groups,rg


### PR DESCRIPTION
# Overview/Summary

Created guidance and ARG for resource group location

AB#32410

## This PR fixes/adds/changes/removes

1. new _index file for resource group 
2. new .kql file for resource group location query
3. Added resource provider for resource group in services-abbreviations.csv


## As part of this Pull Request I have

- [ X] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing) and ensured this PR is compliant with the guide
- [ X] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library/pulls)
- [ X] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
- [ X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
- [ X] Ensured PR tests are passing
- [ X] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries and/or scripts
- [ X] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)

<img width="824" alt="msedge_ueJqVgmDzH" src="https://github.com/Azure/Azure-Proactive-Resiliency-Library/assets/56547666/2d3b5ba7-6f28-4e65-a88f-c7f0d6e7a503">
<img width="929" alt="msedge_Ee9jdcJkJJ" src="https://github.com/Azure/Azure-Proactive-Resiliency-Library/assets/56547666/b258201c-9c59-4feb-9100-24c703c5b74d">
<img width="941" alt="msedge_OesHfw1KiX" src="https://github.com/Azure/Azure-Proactive-Resiliency-Library/assets/56547666/e51f0d3e-06f9-4a16-aa4e-427102b8d2b8">
