### PR TITLE
Update services-abbreviations.csv

### DIFF
--- a/services-abbreviations.csv
+++ b/services-abbreviations.csv
@@ -11,7 +11,6 @@ microsoft.documentdb/databaseaccounts,Azure Cosmos DB database,cosmos
 microsoft.sql/servers/databases,Azure SQL database,sqldb
 microsoft.operationalinsights/workspaces,Log Analytics workspace,log
 microsoft.network/applicationgateways,Application gateway,agw
-microsoft.network/connections,Ddos Protection Plan,ddos
 microsoft.network/privatednszones,Private DNS Zone,pvdnsz
 microsoft.network/azurefirewalls,Azure Firewall,afw
 microsoft.network/expressroutecircuits,ExpressRoute Circuit,erc
@@ -29,11 +28,9 @@ microsoft.network/trafficmanagerprofiles,Traffic Manager profiles,traf
 microsoft.network/virtualnetworks,Virtual network,vnet
 microsoft.keyvault/vaults,Key vault,kv
 microsoft.network/vpngateways,VPN Gateway,vpng
-microsoft.network/virtualNetworkGateways,VPN Gateway,vpng
 microsoft.network/firewallpolicies,Web Application Firewall,waf
 microsoft.netapp/netappaccounts,Azure NetApp Files,anf
 microsoft.storage/storageaccounts,Storage account,st
-microsoft.recoveryservices/vaults,Azure Site Recovery,asr
 microsoft.compute/galleries,Compute Gallery,cg
 microsoft.dbforpostgresql/flexibleservers,DB for PostgreSQL,psql
 microsoft.cache/redis,Redis Cache,redis
@@ -46,7 +43,6 @@ microsoft.insights/components,Application Insights,appi
 microsoft.insights/activitylogalerts,Resource Health Alerts,msr
 microsoft.network/connections,ExpressRoute Connection,ercon
 microsoft.network/expressrouteports,ExpressRoute Direct,erd
-microsoft.network/expressrouteports,ExpressRoute Traffic Collector,ertc
 microsoft.desktopvirtualization/hostpools,Azure Virtual Desktop,avd
 microsoft.avs/privateclouds,Azure VMware Solution,avs
 microsoft.signalrservice/signalr,SignalR,sigr


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

The tool today is not capable to deal with the situation where two services have the same resource provider. When there are duplicated entries for ResourceType, the script uses the last one it captured from the CSV.

## Related Issues/Work Items

NA

## This PR fixes/adds/changes/removes

1. Removes duplicate service abbreviations with the same resourcetype.
2. Removes service abbreviations that dont have recommendations page such as DDoS.

### Breaking Changes

None

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
- [x] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries and/or scripts
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
