### PR TITLE
agw-9 Ensure Application Gateway Subnet is using a /24 subnet mask

### DIFF
--- a/docs/content/services/networking/application-gateway/code/agw-9/agw-9.kql
+++ b/docs/content/services/networking/application-gateway/code/agw-9/agw-9.kql
@@ -1,1 +1,14 @@
-// cannot-be-validated-with-arg
+// Azure Resource Graph Query
+// This query will validate the subnet id for an appGW ends with a /24
+
+resources
+| where type =~ 'Microsoft.Network/applicationGateways'
+| extend subnetid = tostring(properties.gatewayIPConfigurations[0].properties.subnet.id)
+| join kind=leftouter(resources
+    | where type == "microsoft.network/virtualnetworks"
+    | mv-expand properties.subnets
+    | extend subnetid = tostring(properties_subnets.id)
+    | extend addressprefix = tostring(properties_subnets.properties.addressPrefix)
+    | project subnetid, addressprefix) on subnetid
+| where addressprefix !endswith '/24'
+| project recommendationID = "agw-8", name, id, tags, param1 = strcat('AppGW subnet prefix: ', addressprefix)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

KQL for agw-9 - Ensure Application Gateway Subnet is using a /24 subnet mask.  This initially said could not be validated, so either some property changed or I'm grossly misunderstanding the recommendation.  The query is hard coded to look at the first index of gatewayIPConfiguration for the subnet id, but I don't think it's possible to associate more than one subnet with a single app gateway.  If I'm incorrect here, I can adjust the query. 

## Related Issues/Work Items

N/A

## This PR fixes/adds/changes/removes

1. agw-9 KQL

<img width="1871" alt="image" src="https://github.com/Azure/Azure-Proactive-Resiliency-Library/assets/20292838/f2795e4a-cda4-4fbb-bbf2-86e58e63a4a2">


### Breaking Changes

NA

## As part of this Pull Request I have

- [X] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing) and ensured this PR is compliant with the guide
- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library/pulls)
- [X] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
- [X] Ensured PR tests are passing
- [X] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries and/or scripts
- [X] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
