### PR TITLE
rosanto - Updating WADP-2 content which was missing.

### DIFF
--- a/docs/content/well-architected/4-deploy/_index.md
+++ b/docs/content/well-architected/4-deploy/_index.md
@@ -53,7 +53,7 @@ Key Points:
 
 <br><br>
 
-### WADP-2 - Validated all changes in development environments before applying them to Production
+### WADP-2 - Validated all changes in development environments before applying them to production
 
 **Category: Automation**
 
@@ -61,7 +61,7 @@ Key Points:
 
 **Recommendation/Guidance**
 
-FILL ME IN...
+Continuously delivering value has become a mandatory requirement for organizations. To deliver value to your end users, you must release continually and without errors. Continuous delivery (CD) is the process of automating build, test, configuration, and deployment from a build to a production environment. A release pipeline can create multiple testing or staging environments to automate infrastructure creation and deploy new builds. Successive environments support progressively longer-running integration, load, and user acceptance testing activities.
 
 **Resources**
 


### PR DESCRIPTION
# Overview/Summary

rosanto - Updating WADP-2 content which was missing.

## Related Issues/Work Items
rosanto - Updating WADP-2 content which was missing.

## This PR fixes/adds/changes/removes

rosanto - Updating WADP-2 content which was missing.

## As part of this Pull Request I have

- [ x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing) and ensured this PR is compliant with the guide
- [x ] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library/pulls)
- [x ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
- [ x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
- [x ] Ensured PR tests are passing
- [ x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries and/or scripts
- [ x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
