### PR TITLE
Fix ST-3 query

### DIFF
--- a/docs/content/services/storage/storage-Account/_index.md
+++ b/docs/content/services/storage/storage-Account/_index.md
@@ -100,7 +100,8 @@ Consider using appropriate storage performance tier for standard storage / block
 
 **Resources**
 
-- [Performance Tier](https://learn.microsoft.com/azure/storage/common/storage-account-overview#performance-tiers )
+- [Types of storage accounts](https://learn.microsoft.com/en-us/azure/storage/common/storage-account-overview#types-of-storage-accounts)
+- [Legacy storage account types](https://learn.microsoft.com/en-us/azure/storage/common/storage-account-overview#legacy-storage-account-types)
 
 **Resource Graph Query/Scripts**
 

--- a/docs/content/services/storage/storage-Account/code/st-3/st-3.kql
+++ b/docs/content/services/storage/storage-Account/code/st-3/st-3.kql
@@ -1,6 +1,9 @@
 // Azure Resource Graph Query
-// Find all Azure Storage Accounts, that do not have an access tier set
-resources
-| where type =~'microsoft.storage/storageaccounts'
-| where isnull(properties.accessTier)
-| project recommendationId = 'st-3', name, id, param1="not defined - GeneralPurpose V1"
+// Find all Azure Storage Accounts, that upgradeable to General purpose v2.
+Resources
+| where type =~ "Microsoft.Storage/storageAccounts" and kind in~ ("Storage", "BlobStorage")
+| extend
+    param1 = strcat("AccountKind: ", case(kind =~ "Storage", "Storage (general purpose v1)", kind =~ "BlobStorage", "BlobStorage", kind)),
+    param2 = strcat("Performance: ", sku.tier),
+    param3 = strcat("Replication: ", sku.name)
+| project recommendationId = "st-3", name, id, param1, param2, param3


### PR DESCRIPTION
# Overview/Summary

Fixed ST-3 query. The fixed query returns all storage accounts that upgradeable to General purpose v2.

**Note 1**: The guidance of ST-3 is unclear. Because Performance tier means Standard or Premium. It is just a choice; one is not better than the other. Also, block blob, append blob and page blob are types of blobs, not related to performance tier. In addition, file share is storage of file service, it does not compare with blob service.

- https://azure.github.io/Azure-Proactive-Resiliency-Library/services/storage/storage-account/#st-3---ensure-performance-tier-is-set-as-per-workload
    > **Guidance**
    > Consider using appropriate storage performance tier for standard storage / block blob / append blob / file-share and page blob. Each workload scenario requires appropriate Performance tier and its important that based on the type of transaction and blob type/file type appropriate performance tier is selected. Failing to do so will create performance bottleneck.

**Note 2**: Access tier is related to cost (& time to first byte), not storage performance.

- [Access tiers for blob data](https://learn.microsoft.com/en-us/azure/storage/blobs/access-tiers-overview)

## Related Issues/Work Items

- #297

## This PR fixes/adds/changes/removes

1. Fixes ST-3 query.
2. Updates links in Resources section.

### Breaking Changes

None

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
- [ ] Ensured PR tests are passing
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries and/or scripts
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)

## Screenshot

- [Test case](https://github.com/tksh164/aprl-testing/tree/main/services/storage/storage-account/test/st-3)

![image](https://github.com/Azure/Azure-Proactive-Resiliency-Library/assets/1618784/e43ab98a-1d68-4a6f-9012-836b3db13b77)
