### PR TITLE
Adding back AVS-1 and 2 with kusto and powershell queries

### DIFF
--- a/docs/content/services/specialized-workloads/azure-vmware-solution/_index.md
+++ b/docs/content/services/specialized-workloads/azure-vmware-solution/_index.md
@@ -14,6 +14,8 @@ The presented resiliency recommendations in this guidance include Azure VMware S
 {{< table style="table-striped" >}}
 |  Recommendation                                   |      Category         |  Impact         |  State            | ARG Query Available |
 | :------------------------------------------------ | :---------------------------------------------------------------------: | :------:        | :------:          | :------:          |
+|[AVS-1 Configure Azure Service Health notification and alerts for AVS](#avs-1---configure-azure-service-health-notification-and-alerts-for-avs) | Monitoring | Medium | Preview | Yes |
+|[AVS-2 Configure Syslog in Diagnostic Settings for AVS](#avs-2---configure-syslog-in-diagnostic-settings-for-avs) | Monitoring | Medium | Preview | Yes |
 |[AVS-3 Configure Azure Monitor Alert warning thresholds for vSAN datastore utilization](#avs-3---configure-azure-monitor-alert-warning-thresholds-for-vsan-datastore-utilization) | Monitoring | High | Preview | Yes |
 |[AVS-4 Enable Stretched Clusters for Multi-AZ Availability of the vSAN Datastore](#avs-4---enable-stretched-clusters-for-multi-az-availability-of-the-vsan-datastore) | Availability | Low | Preview | Yes |
 |[AVS-5 Monitor CPU Utilization to ensure sufficient resources for workloads](#avs-5---monitor-cpu-utilization-to-ensure-sufficient-resources-for-workloads) | Monitoring | Medium | Preview | Yes |
@@ -31,6 +33,58 @@ Definitions of states can be found [here]({{< ref "../../../_index.md#definition
 {{< /alert >}}
 
 ## Recommendations Details
+
+### AVS-1 - Configure Azure Service Health notification and alerts for AVS
+
+**Category: Monitoring**
+
+**Impact: Medium**
+
+**Recommendation/Guidance**
+
+Ensure Azure Service Health notifications and alerts are configured for the Azure VMware Solution(AVS) service in the subscriptions and regions where AVS is deployed.
+
+Azure Service Health is the mechanism used to inform customers of any service or security issues affecting their private cloud deployment.  Additionally, Azure Service Health is used to inform customers of maintenance activities in their AVS environments including host replacements, upgrades, and any service updates which could potentially impact customer operations. Proper configuration of Azure Service Health notifications and alerts ensures that customers receive relevant notifications and can reduce service request submissions due to AVS maintenance.
+
+**Resources**
+
+- [Learn More](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/scenarios/azure-vmware/eslz-management-and-monitoring#design-recommendations)
+
+**Resource Graph Query/Scripts**
+
+{{< collapse title="Show/Hide Query/Script" >}}
+
+{{< code lang="sql" file="code/avs-1/avs-1.kql" >}} {{< /code >}}
+
+{{< /collapse >}}
+
+<br><br>
+
+### AVS-2 - Configure Syslog in Diagnostic Settings for AVS
+
+**Category: Monitoring**
+
+**Impact: Medium**
+
+**Recommendation/Guidance**
+
+Ensure Diagnostic Settings are configured for each private cloud to send the syslogs to one or more external sources for analysis and/or archiving.
+
+Azure VMware Solution Syslogs have useful data for troubleshooting and performance that can help with quicker issue resolution and can also enable early detection of some kinds of issues. Configure Diagnostic Settings on the private cloud to send the Syslogs to one or more external sources for querying and/or archiving in case of an audit.
+
+**Resources**
+
+- [Learn More](https://learn.microsoft.com/en-us/azure/well-architected/azure-vmware/monitoring#manage-logs-and-archives)
+
+**Resource Graph Query/Scripts**
+
+{{< collapse title="Show/Hide Query/Script" >}}
+
+{{< code lang="powershell" file="code/avs-2/avs-2.ps1" >}} {{< /code >}}
+
+{{< /collapse >}}
+
+<br><br>
 
 ### AVS-3 - Configure Azure Monitor Alert warning thresholds for vSAN datastore utilization
 

--- a/docs/content/services/specialized-workloads/azure-vmware-solution/_index.md
+++ b/docs/content/services/specialized-workloads/azure-vmware-solution/_index.md
@@ -16,7 +16,7 @@ The presented resiliency recommendations in this guidance include Azure VMware S
 | :------------------------------------------------ | :---------------------------------------------------------------------: | :------:        | :------:          | :------:          |
 |[AVS-1 Configure Azure Service Health notification and alerts for AVS](#avs-1---configure-azure-service-health-notification-and-alerts-for-avs) | Monitoring | Medium | Preview | Yes |
 |[AVS-2 Configure Syslog in Diagnostic Settings for AVS](#avs-2---configure-syslog-in-diagnostic-settings-for-avs) | Monitoring | Medium | Preview | Yes |
-|[AVS-3 Configure Azure Monitor Alert warning thresholds for vSAN datastore utilization](#avs-3---configure-azure-monitor-alert-warning-thresholds-for-vsan-datastore-utilization) | Monitoring | High | Preview | Yes |
+|[AVS-3 Configure Azure Monitor Alert warning thresholds for vSAN datastore utilization](#avs-3---configure-azure-monitor-alert-warning-thresholds-for-vsan-datastore-utilization) | Monitoring | High | Preview | No |
 |[AVS-4 Enable Stretched Clusters for Multi-AZ Availability of the vSAN Datastore](#avs-4---enable-stretched-clusters-for-multi-az-availability-of-the-vsan-datastore) | Availability | Low | Preview | Yes |
 |[AVS-5 Monitor CPU Utilization to ensure sufficient resources for workloads](#avs-5---monitor-cpu-utilization-to-ensure-sufficient-resources-for-workloads) | Monitoring | Medium | Preview | Yes |
 |[AVS-6 Monitor Memory Utilization to ensure sufficient resources for workloads](#avs-6---monitor-memory-utilization-to-ensure-sufficient-resources-for-workloads) | Monitoring | Medium | Preview | Yes |

--- a/docs/content/services/specialized-workloads/azure-vmware-solution/code/avs-1/avs-1.kql
+++ b/docs/content/services/specialized-workloads/azure-vmware-solution/code/avs-1/avs-1.kql
@@ -1,0 +1,37 @@
+// Azure Resource Graph Query
+// Provides a list of Azure VMware Solution resources that don't have one or more service health alerts covering AVS private clouds in the deployed subscription and region pairs.
+//full list of private clouds
+(resources
+| where ['type'] == "microsoft.avs/privateclouds"
+| extend locale = location
+| project id, name, tags, subscriptionId, locale)
+| join kind=leftouter
+//Alert ID's that include all incident types filtered by AVS Service Health alerts
+((resources
+| where type == "microsoft.insights/activitylogalerts"
+| extend alertproperties = todynamic(properties)
+| where alertproperties.condition.allOf[0].field == "category" and alertproperties.condition.allOf[0].equals == "ServiceHealth"
+| where alertproperties.condition.allOf[1].field == "properties.impactedServices[*].ServiceName" and set_has_element(alertproperties.condition.allOf[1].containsAny, "Azure VMware Solution")
+| extend locale = strcat_array(split(tolower(alertproperties.condition.allOf[2].containsAny),' '), '')
+| mv-expand todynamic(locale)
+| where locale != "global"
+| project subscriptionId, tostring(locale) )
+| union
+//Alert ID's that include only some of the incident types after filtering by service health alerts covering AVS private clouds.
+(resources
+| where type == "microsoft.insights/activitylogalerts"
+| extend alertproperties = todynamic(properties)
+| where alertproperties.condition.allOf[0].field == "category" and alertproperties.condition.allOf[0].equals == "ServiceHealth"
+| where alertproperties.condition.allOf[2].field == "properties.impactedServices[*].ServiceName" and set_has_element(alertproperties.condition.allOf[2].containsAny, "Azure VMware Solution")
+| extend locale = strcat_array(split(tolower(alertproperties.condition.allOf[3].containsAny),' '), '')
+| mv-expand todynamic(locale)
+| mv-expand alertproperties.condition.allOf[1].anyOf
+| extend incidentType = alertproperties_condition_allOf_1_anyOf.equals
+| where locale != "global"
+| project id, subscriptionId, locale, incidentType
+| distinct subscriptionId, tostring(locale), tostring(incidentType)
+| summarize incidentTypes=count() by subscriptionId, locale
+| where incidentTypes == 5 //only include this subscription, region pair if it includes all the incident types.
+| project subscriptionId, locale)) on subscriptionId, locale
+| where subscriptionId1 == "" or locale1 == "" or isnull(subscriptionId1) or isnull(locale1)
+| project recommendationId = "avs-1", name, id, tags, param1 = "avsServiceHealthAlertsAllIncidentTypesConfigured: False"

--- a/docs/content/services/specialized-workloads/azure-vmware-solution/code/avs-2/avs-2.ps1
+++ b/docs/content/services/specialized-workloads/azure-vmware-solution/code/avs-2/avs-2.ps1
@@ -1,0 +1,36 @@
+# Azure PowerShell script
+# Provides a list of private clouds that don't have a diagnostic setting configured to export the logs
+$output = @()
+$privateClouds = get-AzVMwarePrivateCloud
+foreach ($privateCloud in $privateClouds) {
+    $ds = Get-AzDiagnosticSetting -ResourceId $privateCloud.id
+
+    if (!$ds) {
+        $output += [PSCustomObject] @{ #no diagnostic settings values
+            recommendationId = 'aks-2'
+            name             = $privateCloud.Name
+            id               = $privateCloud.Id
+            tags             = if ($privateCloud.tag) { $privateCloud.tag } else { $null }
+            param1           = 'exportSyslogWithDiagnosticSetting:false'
+        }
+    }
+
+    if ($ds) {
+        $fixFlag = $false
+        foreach ($log in $ds.log) { #diagnostic settings exist but not for logs
+            if (($log.CategoryGroup -eq "allLogs") -and ($log.Enabled -eq $false)){ $fixFlag = $true}
+            if (($log.Category -eq "vmwaresyslog") -and ($log.Enabled -eq $false)){ $fixFlag = $true}
+        }
+        if ($fixFlag){
+            $output += [PSCustomObject] @{
+                recommendationId = 'aks-2'
+                name             = $privateCloud.Name
+                id               = $privateCloud.Id
+                tags             = if ($privateCloud.tag) { $privateCloud.tag } else { $null }
+                param1           = 'exportSyslogWithDiagnosticSetting:false'
+            }
+        }
+    }
+}
+
+$output


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Adds back AVS-1 and AVS-2 recommendations.  Includes a kusto query for AVS-1, and a powershell script for AVS-2

## Related Issues/Work Items

## This PR fixes/adds/changes/removes

1. Adds AVS-1 and AVS-2 Recommendation text
2. Creates a kusto query for AVS-1
3. Creates a powershell query for AVS-2

### Breaking Changes

1. None

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
- [x] Ensured PR tests are passing
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries and/or scripts
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
