### PR TITLE
evhns-2 kql -  Enable auto-inflate on Event Hub Standard tier

### DIFF
--- a/docs/content/services/integration/event-hub/_index.md
+++ b/docs/content/services/integration/event-hub/_index.md
@@ -15,7 +15,7 @@ The presented resiliency recommendations in this guidance include Event Hub and 
 | Recommendation                                    |  Category                                                               |  Impact         |  State            | ARG Query Available |
 | :------------------------------------------------ | :---------------------------------------------------------------------: | :------:        | :------:          | :-----------------: |
 | [EVHNS-1 - Enable zone redundancy for Event Hub namespace](#evhns-1---enable-zone-redundancy-for-event-hub-namespace) | High Availability | High | Preview  |         Yes         |
-| [EVHNS-2 - Enable auto-inflate on Event Hub Standard tier](#evhns-2---enable-auto-inflate-on-event-hub-standard-tier) | System Efficiency | High | Preview | No |
+| [EVHNS-2 - Enable auto-inflate on Event Hub Standard tier](#evhns-2---enable-auto-inflate-on-event-hub-standard-tier) | System Efficiency | High | Preview | Yes |
 {{< /table >}}
 
 {{< alert style="info" >}}

--- a/docs/content/services/integration/event-hub/code/evhns-2/evhns-2.kql
+++ b/docs/content/services/integration/event-hub/code/evhns-2/evhns-2.kql
@@ -1,1 +1,7 @@
-// under-development
+// Azure Resource Graph Query
+// Find Event Hub namespace instances that are Standard tier and do not have Auto Inflate enabled
+resources
+| where type == "microsoft.eventhub/namespaces"
+| where sku.tier == "Standard"
+| where properties.isAutoInflateEnabled == "false"
+| project recommendationId = "evhns-2", name, id, tags, param1 = "AutoInflateEnabled: False"


### PR DESCRIPTION
# Overview/Summary

EVHNS-2 KQL - Enable auto-inflate on Event Hub Standard tier

## Related Issues/Work Items

N/A

## This PR fixes/adds/changes/removes

1. Adds kql file for event hub namespace recommendation 2

<img width="1664" alt="image" src="https://github.com/Azure/Azure-Proactive-Resiliency-Library/assets/20292838/c1fdec1c-0703-4631-afb0-eb586e70befc">

## As part of this Pull Request I have

- [X] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing) and ensured this PR is compliant with the guide
- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library/pulls)
- [X] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
- [X] Ensured PR tests are passing
- [X] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries and/or scripts
- [X] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
