### PR TITLE
ACR: Remove CR-4 and re-number CR items

### DIFF
--- a/docs/content/services/container/container-registry/_index.md
+++ b/docs/content/services/container/container-registry/_index.md
@@ -17,14 +17,13 @@ The presented resiliency recommendations in this guidance include Container Regi
 | [CR-1 - Use Premium tier for critical production workloads](#cr-1---use-premium-tier-for-critical-production-workloads) | System Efficiency | High | Preview | Yes |
 | [CR-2 - Enable zone redundancy](#cr-2---enable-zone-redundancy) | Availability | High | Preview | Yes |
 | [CR-3 - Enable geo-replication](#cr-3---enable-geo-replication) | Disaster Recovery | High | Preview | Yes |
-| [CR-4 - Maximize pull performance](#cr-4---maximize-pull-performance) | System Efficiency | High | Preview | No |
-| [CR-5 - Use Repository namespaces](#cr-5---use-repository-namespaces) | Access & Security | Low | Preview | No |
-| [CR-6 - Move Container Registry to a dedicated resource group](#cr-6---move-container-registry-to-a-dedicated-resource-group) | Governance | Low | Preview | Yes |
-| [CR-7 - Manage registry size](#cr-7---manage-registry-size) | System Efficiency | Medium | Preview | No |
-| [CR-8 - Disable anonymous pull access](#cr-8---disable-anonymous-pull-access) | Access & Security | Medium | Preview | Yes |
-| [CR-10 - Configure Diagnostic Settings for all Azure Container Registries](#cr-10---configure-diagnostic-settings-for-all-azure-container-registries) | Monitoring | Medium | Preview | No |
-| [CR-11 - Monitor Azure Container Registry with Azure Monitor](#cr-11---monitor-azure-container-registry-with-azure-monitor) | Monitoring | Medium | Preview | No |
-| [CR-12 - Enable soft delete policy](#cr-12---enable-soft-delete-policy) | Disaster Recovery | Medium | Preview | Yes |
+| [CR-4 - Use Repository namespaces](#cr-4---use-repository-namespaces) | Access & Security | Low | Preview | No |
+| [CR-5 - Move Container Registry to a dedicated resource group](#cr-5---move-container-registry-to-a-dedicated-resource-group) | Governance | Low | Preview | Yes |
+| [CR-6 - Manage registry size](#cr-6---manage-registry-size) | System Efficiency | Medium | Preview | No |
+| [CR-7 - Disable anonymous pull access](#cr-7---disable-anonymous-pull-access) | Access & Security | Medium | Preview | Yes |
+| [CR-8 - Configure Diagnostic Settings for all Azure Container Registries](#cr-8---configure-diagnostic-settings-for-all-azure-container-registries) | Monitoring | Medium | Preview | No |
+| [CR-9 - Monitor Azure Container Registry with Azure Monitor](#cr-9---monitor-azure-container-registry-with-azure-monitor) | Monitoring | Medium | Preview | No |
+| [CR-10 - Enable soft delete policy](#cr-10---enable-soft-delete-policy) | Disaster Recovery | Medium | Preview | Yes |
 {{< /table >}}
 
 {{< alert style="info" >}}
@@ -108,35 +107,7 @@ Geo-replication is available with Premium registries.
 
 <br><br>
 
-### CR-4 - Maximize pull performance
-
-**Category: System Efficiency**
-
-**Impact: High**
-
-**Guidance**
-
-Some characteristics of your images themselves can impact pull performance:
-
-- Image size - Minimize the sizes of your images by removing unnecessary layers or reducing the size of layers. One way to reduce image size is to use the multi-stage Docker build approach to include only the necessary runtime components. Also check whether your image can include a lighter base OS image. And if you use a deployment environment such as Azure Container Instances that caches certain base images, check whether you can swap an image layer for one of the cached images.
-
-- Number of layers - Balance the number of layers used. If you have too few, you don’t benefit from layer reuse and caching on the host. Too many, and your deployment environment spends more time pulling and decompressing. Five to 10 layers is optimal.
-
-**Resources**
-
-- [Registry authentication options - Azure Container Registry](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-authentication?tabs=azure-cli#admin-account)
-
-**Resource Graph Query/Scripts**
-
-{{< collapse title="Show/Hide Query/Script" >}}
-
-{{< code lang="sql" file="code/cr-4/cr-4.kql" >}} {{< /code >}}
-
-{{< /collapse >}}
-
-<br><br>
-
-### CR-5 - Use Repository namespaces
+### CR-4 - Use Repository namespaces
 
 **Category: Access & Security**
 
@@ -154,12 +125,12 @@ By using repository namespaces, you can allow sharing a single registry across m
 
 {{< collapse title="Show/Hide Query/Script" >}}
 
-{{< code lang="sql" file="code/cr-5/cr-5.kql" >}} {{< /code >}}
+{{< code lang="sql" file="code/cr-4/cr-4.kql" >}} {{< /code >}}
 
 {{< /collapse >}}
 <br><br>
 
-### CR-6 - Move Container Registry to a dedicated resource group
+### CR-5 - Move Container Registry to a dedicated resource group
 
 **Category: Governance**
 
@@ -179,13 +150,13 @@ Although you might experiment with a specific host type, such as Azure Container
 
 {{< collapse title="Show/Hide Query/Script" >}}
 
-{{< code lang="sql" file="code/cr-6/cr-6.kql" >}} {{< /code >}}
+{{< code lang="sql" file="code/cr-5/cr-5.kql" >}} {{< /code >}}
 
 {{< /collapse >}}
 
 <br><br>
 
-### CR-7 - Manage registry size
+### CR-6 - Manage registry size
 
 **Category: System Efficiency**
 
@@ -204,13 +175,13 @@ The storage constraints of each container registry service tier are intended to 
 
 {{< collapse title="Show/Hide Query/Script" >}}
 
-{{< code lang="sql" file="code/cr-7/cr-7.kql" >}} {{< /code >}}
+{{< code lang="sql" file="code/cr-6/cr-6.kql" >}} {{< /code >}}
 
 {{< /collapse >}}
 
 <br><br>
 
-### CR-8 - Disable anonymous pull access
+### CR-7 - Disable anonymous pull access
 
 **Category: Access & Security**
 
@@ -228,13 +199,13 @@ By default, access to pull or push content from an Azure container registry is o
 
 {{< collapse title="Show/Hide Query/Script" >}}
 
-{{< code lang="sql" file="code/cr-8/cr-8.kql" >}} {{< /code >}}
+{{< code lang="sql" file="code/cr-7/cr-7.kql" >}} {{< /code >}}
 
 {{< /collapse >}}
 
 <br><br>
 
-### CR-10 - Configure Diagnostic Settings for all Azure Container Registries
+### CR-8 - Configure Diagnostic Settings for all Azure Container Registries
 
 **Category: Monitoring**
 
@@ -253,12 +224,12 @@ Resource Logs are not collected and stored until you create a diagnostic setting
 
 {{< collapse title="Show/Hide Query/Script" >}}
 
-{{< code lang="sql" file="code/cr-10/cr-10.kql" >}} {{< /code >}}
+{{< code lang="sql" file="code/cr-8/cr-8.kql" >}} {{< /code >}}
 
 {{< /collapse >}}
 <br><br>
 
-### CR-11 - Monitor Azure Container Registry with Azure Monitor
+### CR-9 - Monitor Azure Container Registry with Azure Monitor
 
 **Category: Monitoring**
 
@@ -277,13 +248,13 @@ When you have critical applications and business processes relying on Azure reso
 
 {{< collapse title="Show/Hide Query/Script" >}}
 
-{{< code lang="sql" file="code/cr-11/cr-11.kql" >}} {{< /code >}}
+{{< code lang="sql" file="code/cr-9/cr-9.kql" >}} {{< /code >}}
 
 {{< /collapse >}}
 
 <br><br>
 
-### CR-12 - Enable soft delete policy
+### CR-10 - Enable soft delete policy
 
 **Category: Disaster Recovery**
 
@@ -301,7 +272,7 @@ Once you enable the soft delete policy, ACR manages the deleted artifacts as the
 
 {{< collapse title="Show/Hide Query/Script" >}}
 
-{{< code lang="sql" file="code/cr-12/cr-12.kql" >}} {{< /code >}}
+{{< code lang="sql" file="code/cr-10/cr-10.kql" >}} {{< /code >}}
 
 {{< /collapse >}}
 

--- a/docs/content/services/container/container-registry/_index.md
+++ b/docs/content/services/container/container-registry/_index.md
@@ -17,13 +17,14 @@ The presented resiliency recommendations in this guidance include Container Regi
 | [CR-1 - Use Premium tier for critical production workloads](#cr-1---use-premium-tier-for-critical-production-workloads) | System Efficiency | High | Preview | Yes |
 | [CR-2 - Enable zone redundancy](#cr-2---enable-zone-redundancy) | Availability | High | Preview | Yes |
 | [CR-3 - Enable geo-replication](#cr-3---enable-geo-replication) | Disaster Recovery | High | Preview | Yes |
-| [CR-4 - Use Repository namespaces](#cr-4---use-repository-namespaces) | Access & Security | Low | Preview | No |
-| [CR-5 - Move Container Registry to a dedicated resource group](#cr-5---move-container-registry-to-a-dedicated-resource-group) | Governance | Low | Preview | Yes |
-| [CR-6 - Manage registry size](#cr-6---manage-registry-size) | System Efficiency | Medium | Preview | No |
-| [CR-7 - Disable anonymous pull access](#cr-7---disable-anonymous-pull-access) | Access & Security | Medium | Preview | Yes |
-| [CR-8 - Configure Diagnostic Settings for all Azure Container Registries](#cr-8---configure-diagnostic-settings-for-all-azure-container-registries) | Monitoring | Medium | Preview | No |
-| [CR-9 - Monitor Azure Container Registry with Azure Monitor](#cr-9---monitor-azure-container-registry-with-azure-monitor) | Monitoring | Medium | Preview | No |
-| [CR-10 - Enable soft delete policy](#cr-10---enable-soft-delete-policy) | Disaster Recovery | Medium | Preview | Yes |
+| [CR-4 - Maximize pull performance](#cr-4---maximize-pull-performance) | System Efficiency | High | Preview | No |
+| [CR-5 - Use Repository namespaces](#cr-5---use-repository-namespaces) | Access & Security | Low | Preview | No |
+| [CR-6 - Move Container Registry to a dedicated resource group](#cr-6---move-container-registry-to-a-dedicated-resource-group) | Governance | Low | Preview | Yes |
+| [CR-7 - Manage registry size](#cr-7---manage-registry-size) | System Efficiency | Medium | Preview | No |
+| [CR-8 - Disable anonymous pull access](#cr-8---disable-anonymous-pull-access) | Access & Security | Medium | Preview | Yes |
+| [CR-10 - Configure Diagnostic Settings for all Azure Container Registries](#cr-10---configure-diagnostic-settings-for-all-azure-container-registries) | Monitoring | Medium | Preview | No |
+| [CR-11 - Monitor Azure Container Registry with Azure Monitor](#cr-11---monitor-azure-container-registry-with-azure-monitor) | Monitoring | Medium | Preview | No |
+| [CR-12 - Enable soft delete policy](#cr-12---enable-soft-delete-policy) | Disaster Recovery | Medium | Preview | Yes |
 {{< /table >}}
 
 {{< alert style="info" >}}
@@ -107,7 +108,35 @@ Geo-replication is available with Premium registries.
 
 <br><br>
 
-### CR-4 - Use Repository namespaces
+### CR-4 - Maximize pull performance
+
+**Category: System Efficiency**
+
+**Impact: High**
+
+**Guidance**
+
+Some characteristics of your images themselves can impact pull performance:
+
+- Image size - Minimize the sizes of your images by removing unnecessary layers or reducing the size of layers. One way to reduce image size is to use the multi-stage Docker build approach to include only the necessary runtime components. Also check whether your image can include a lighter base OS image. And if you use a deployment environment such as Azure Container Instances that caches certain base images, check whether you can swap an image layer for one of the cached images.
+
+- Number of layers - Balance the number of layers used. If you have too few, you don’t benefit from layer reuse and caching on the host. Too many, and your deployment environment spends more time pulling and decompressing. Five to 10 layers is optimal.
+
+**Resources**
+
+- [Registry authentication options - Azure Container Registry](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-authentication?tabs=azure-cli#admin-account)
+
+**Resource Graph Query/Scripts**
+
+{{< collapse title="Show/Hide Query/Script" >}}
+
+{{< code lang="sql" file="code/cr-4/cr-4.kql" >}} {{< /code >}}
+
+{{< /collapse >}}
+
+<br><br>
+
+### CR-5 - Use Repository namespaces
 
 **Category: Access & Security**
 
@@ -125,12 +154,12 @@ By using repository namespaces, you can allow sharing a single registry across m
 
 {{< collapse title="Show/Hide Query/Script" >}}
 
-{{< code lang="sql" file="code/cr-4/cr-4.kql" >}} {{< /code >}}
+{{< code lang="sql" file="code/cr-5/cr-5.kql" >}} {{< /code >}}
 
 {{< /collapse >}}
 <br><br>
 
-### CR-5 - Move Container Registry to a dedicated resource group
+### CR-6 - Move Container Registry to a dedicated resource group
 
 **Category: Governance**
 
@@ -150,13 +179,13 @@ Although you might experiment with a specific host type, such as Azure Container
 
 {{< collapse title="Show/Hide Query/Script" >}}
 
-{{< code lang="sql" file="code/cr-5/cr-5.kql" >}} {{< /code >}}
+{{< code lang="sql" file="code/cr-6/cr-6.kql" >}} {{< /code >}}
 
 {{< /collapse >}}
 
 <br><br>
 
-### CR-6 - Manage registry size
+### CR-7 - Manage registry size
 
 **Category: System Efficiency**
 
@@ -175,13 +204,13 @@ The storage constraints of each container registry service tier are intended to 
 
 {{< collapse title="Show/Hide Query/Script" >}}
 
-{{< code lang="sql" file="code/cr-6/cr-6.kql" >}} {{< /code >}}
+{{< code lang="sql" file="code/cr-7/cr-7.kql" >}} {{< /code >}}
 
 {{< /collapse >}}
 
 <br><br>
 
-### CR-7 - Disable anonymous pull access
+### CR-8 - Disable anonymous pull access
 
 **Category: Access & Security**
 
@@ -199,13 +228,13 @@ By default, access to pull or push content from an Azure container registry is o
 
 {{< collapse title="Show/Hide Query/Script" >}}
 
-{{< code lang="sql" file="code/cr-7/cr-7.kql" >}} {{< /code >}}
+{{< code lang="sql" file="code/cr-8/cr-8.kql" >}} {{< /code >}}
 
 {{< /collapse >}}
 
 <br><br>
 
-### CR-8 - Configure Diagnostic Settings for all Azure Container Registries
+### CR-10 - Configure Diagnostic Settings for all Azure Container Registries
 
 **Category: Monitoring**
 
@@ -224,12 +253,12 @@ Resource Logs are not collected and stored until you create a diagnostic setting
 
 {{< collapse title="Show/Hide Query/Script" >}}
 
-{{< code lang="sql" file="code/cr-8/cr-8.kql" >}} {{< /code >}}
+{{< code lang="sql" file="code/cr-10/cr-10.kql" >}} {{< /code >}}
 
 {{< /collapse >}}
 <br><br>
 
-### CR-9 - Monitor Azure Container Registry with Azure Monitor
+### CR-11 - Monitor Azure Container Registry with Azure Monitor
 
 **Category: Monitoring**
 
@@ -248,13 +277,13 @@ When you have critical applications and business processes relying on Azure reso
 
 {{< collapse title="Show/Hide Query/Script" >}}
 
-{{< code lang="sql" file="code/cr-9/cr-9.kql" >}} {{< /code >}}
+{{< code lang="sql" file="code/cr-11/cr-11.kql" >}} {{< /code >}}
 
 {{< /collapse >}}
 
 <br><br>
 
-### CR-10 - Enable soft delete policy
+### CR-12 - Enable soft delete policy
 
 **Category: Disaster Recovery**
 
@@ -272,7 +301,7 @@ Once you enable the soft delete policy, ACR manages the deleted artifacts as the
 
 {{< collapse title="Show/Hide Query/Script" >}}
 
-{{< code lang="sql" file="code/cr-10/cr-10.kql" >}} {{< /code >}}
+{{< code lang="sql" file="code/cr-12/cr-12.kql" >}} {{< /code >}}
 
 {{< /collapse >}}
 

--- a/docs/content/services/container/container-registry/_index.md
+++ b/docs/content/services/container/container-registry/_index.md
@@ -17,7 +17,6 @@ The presented resiliency recommendations in this guidance include Container Regi
 | [CR-1 - Use Premium tier for critical production workloads](#cr-1---use-premium-tier-for-critical-production-workloads) | System Efficiency | High | Preview | Yes |
 | [CR-2 - Enable zone redundancy](#cr-2---enable-zone-redundancy) | Availability | High | Preview | Yes |
 | [CR-3 - Enable geo-replication](#cr-3---enable-geo-replication) | Disaster Recovery | High | Preview | Yes |
-| [CR-4 - Maximize pull performance](#cr-4---maximize-pull-performance) | System Efficiency | High | Preview | No |
 | [CR-5 - Use Repository namespaces](#cr-5---use-repository-namespaces) | Access & Security | Low | Preview | No |
 | [CR-6 - Move Container Registry to a dedicated resource group](#cr-6---move-container-registry-to-a-dedicated-resource-group) | Governance | Low | Preview | Yes |
 | [CR-7 - Manage registry size](#cr-7---manage-registry-size) | System Efficiency | Medium | Preview | No |
@@ -103,34 +102,6 @@ Geo-replication is available with Premium registries.
 {{< collapse title="Show/Hide Query/Script" >}}
 
 {{< code lang="sql" file="code/cr-3/cr-3.kql" >}} {{< /code >}}
-
-{{< /collapse >}}
-
-<br><br>
-
-### CR-4 - Maximize pull performance
-
-**Category: System Efficiency**
-
-**Impact: High**
-
-**Guidance**
-
-Some characteristics of your images themselves can impact pull performance:
-
-- Image size - Minimize the sizes of your images by removing unnecessary layers or reducing the size of layers. One way to reduce image size is to use the multi-stage Docker build approach to include only the necessary runtime components. Also check whether your image can include a lighter base OS image. And if you use a deployment environment such as Azure Container Instances that caches certain base images, check whether you can swap an image layer for one of the cached images.
-
-- Number of layers - Balance the number of layers used. If you have too few, you don’t benefit from layer reuse and caching on the host. Too many, and your deployment environment spends more time pulling and decompressing. Five to 10 layers is optimal.
-
-**Resources**
-
-- [Registry authentication options - Azure Container Registry](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-authentication?tabs=azure-cli#admin-account)
-
-**Resource Graph Query/Scripts**
-
-{{< collapse title="Show/Hide Query/Script" >}}
-
-{{< code lang="sql" file="code/cr-4/cr-4.kql" >}} {{< /code >}}
 
 {{< /collapse >}}
 

--- a/docs/content/services/container/container-registry/code/cr-4/cr-4.kql
+++ b/docs/content/services/container/container-registry/code/cr-4/cr-4.kql
@@ -1,1 +1,0 @@
-// cannot-be-validated-with-arg


### PR DESCRIPTION
# Overview/Summary

Removed CR-4 since it is not applicable to resiliency and re-numbered items. No query changes.

## This PR fixes/adds/changes/removes

1. Removes CR-4
2. Re-numbers CR items - it looked like the numbering was off by one before I did the removal so some of them changed by 2 places instead of one place.

### Breaking Changes
None

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
- [x] Ensured PR tests are passing
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries and/or scripts
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
