### PR TITLE
Update erd-1.kql & erd-2.kql

### DIFF
--- a/docs/content/services/networking/expressroute-direct/code/erd-1/erd-1.kql
+++ b/docs/content/services/networking/expressroute-direct/code/erd-1/erd-1.kql
@@ -3,3 +3,4 @@
 resources
 | where type == "microsoft.network/expressrouteports"
 | where properties['links'][0]['properties']['adminState'] == "Disabled" or properties['links'][1]['properties']['adminState'] == "Disabled"
+| project recommendationId = "erd-1", name, id, tags, param1 = strcat("Link1AdminState: ", properties['links'][0]['properties']['adminState']), param2 = strcat("Link2AdminState: ", properties['links'][1]['properties']['adminState'])

--- a/docs/content/services/networking/expressroute-direct/code/erd-1/erd-1.kql
+++ b/docs/content/services/networking/expressroute-direct/code/erd-1/erd-1.kql
@@ -1,1 +1,5 @@
-// under-development
+// Azure Resource Graph Query
+// Find all Express Route Directs that do not have Admin State of both Links Enabled
+resources
+| where type == "microsoft.network/expressrouteports"
+| where properties['links'][0]['properties']['adminState'] == "Disabled" or properties['links'][1]['properties']['adminState'] == "Disabled"

--- a/docs/content/services/networking/expressroute-direct/code/erd-2/erd-2.kql
+++ b/docs/content/services/networking/expressroute-direct/code/erd-2/erd-2.kql
@@ -1,1 +1,6 @@
-// under-development
+// Azure Resource Graph Query
+// Find all Express Route Directs that are over subscribed
+resources
+| where type == "microsoft.network/expressrouteports"
+| where toint(properties['provisionedBandwidthInGbps']) > toint(properties['bandwidthInGbps'])
+| project recommendationId = "erd-2", name, id, tags, param1 = strcat("provisionedBandwidthInGbps: ", properties['provisionedBandwidthInGbps']), param2 = strcat("bandwidthInGbps: ", properties['bandwidthInGbps'])


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary
Wrote Azure Resource Graph Query to Find all Express Route Directs that do not have Admin State of both Links Enabled

## Related Issues/Work Items

Replace this with a list of related GitHub Issues and/or ADO Work Items (Internal Only)

NA

## This PR fixes/adds/changes/removes

1. Adds Azure Resource Graph Query to Find all Express Route Directs that do not have Admin State of both Links Enabled

### Breaking Changes

NA

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
- [x] Ensured PR tests are passing
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries and/or scripts
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
