### PR TITLE
MS-1: Remove duplicated resource link

### DIFF
--- a/docs/content/services/management/subscription/_index.md
+++ b/docs/content/services/management/subscription/_index.md
@@ -45,7 +45,6 @@ This recommendation checks for 80% of the Citrix limit so that attention can be 
 **Resources**
 
 - [Citrix Limits](https://docs.citrix.com/en-us/citrix-daas-azure/limits)
-- [Citrix Managed Azure subscriptions](https://docs.citrix.com/en-us/citrix-daas-azure/limits)
 
 **Resource Graph Query/Scripts**
 


### PR DESCRIPTION
# Overview/Summary

Removed the duplicated link in the Resources section of [MS-1](https://azure.github.io/Azure-Proactive-Resiliency-Library/services/management/subscription/#ms-1---do-not-create-more-than-2000-citrix-vda-servers-per-subscription). Those have the same link text, but the link URL is the same.

## Related Issues/Work Items

None

## This PR fixes/adds/changes/removes

1. Removes the duplicated link in the Resources section of MS-1.

### Breaking Changes

None

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
- [ ] Ensured PR tests are passing
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries and/or scripts
    - Confirmed that document build succeeded on my local machine.
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
