### PR TITLE
fixed typo and updated KQL issues

### DIFF
--- a/docs/content/services/storage/azure-netapp-files/_index.md
+++ b/docs/content/services/storage/azure-netapp-files/_index.md
@@ -174,7 +174,7 @@ Note: A volume can be replicated via cross-zone replication (CZR) or cross-regio
 
 **Resources**
 
-- [Cross-zone replication of Azure NetApp Files volumes | Microsoft Learn](https://learn.microsoft.com/azure/azure-netapp-files/cross-region-replication-introduction)
+- [Cross-region replication of Azure NetApp Files volumes | Microsoft Learn](https://learn.microsoft.com/azure/azure-netapp-files/cross-region-replication-introduction)
 
 **Resource Graph Query**
 

--- a/docs/content/services/storage/azure-netapp-files/code/anf-6/anf-6.kql
+++ b/docs/content/services/storage/azure-netapp-files/code/anf-6/anf-6.kql
@@ -1,10 +1,8 @@
 // This Resource Graph query will return all Azure NetApp Files volumes without cross-region replication.
 resources
-| where type =~ "microsoft.netapp/netappaccounts/capacitypools/volumes"
-| extend NetAC0 = tostring(split(name,'/')[0])
-| join kind=leftouter (resources
-    | where type =~ "microsoft.netapp/netappaccounts/capacitypools/volumes"
-    | extend NetAC1 = tostring(split(name,'/')[0])
-    | project id,NetAC1,remid=tostring(properties.dataProtection.replication.remoteVolumeResourceId)) on $left.id == $right.remid
-| where properties.volumeType != 'DataProtection' and NetAC0 == NetAC1
-| project recommendationId = "ANF-6", name, id, tags
+| where type == "microsoft.netapp/netappaccounts/capacitypools/volumes"
+| extend remoteVolumeRegion = properties.dataProtection.replication.remoteVolumeRegion
+| extend volumeType = properties.volumeType
+| extend replicationType = iff((remoteVolumeRegion == location), "CZR", iff((remoteVolumeRegion == ""),"n/a","CRR"))
+| where replicationType != "CRR" and volumeType != "DataProtection"
+| project recommendationId = "ANF-6", name, id, tags, replicationType

--- a/docs/content/services/storage/azure-netapp-files/code/anf-7/anf-7.kql
+++ b/docs/content/services/storage/azure-netapp-files/code/anf-7/anf-7.kql
@@ -1,10 +1,8 @@
 // This Resource Graph query will return all Azure NetApp Files volumes without cross-zone replication.
 resources
-| where type =~ "microsoft.netapp/netappaccounts/capacitypools/volumes"
-| extend NetAC0 = tostring(split(name,'/')[0])
-| join kind=leftouter (resources
-    | where type =~ "microsoft.netapp/netappaccounts/capacitypools/volumes"
-    | extend NetAC1 = tostring(split(name,'/')[0])
-    | project id,NetAC1,remid=tostring(properties.dataProtection.replication.remoteVolumeResourceId)) on $left.id == $right.remid
-| where properties.volumeType != 'DataProtection' and NetAC0 != NetAC1
-| project recommendationId = "ANF-7", name, id, tags
+| where type == "microsoft.netapp/netappaccounts/capacitypools/volumes"
+| extend remoteVolumeRegion = properties.dataProtection.replication.remoteVolumeRegion
+| extend volumeType = properties.volumeType
+| extend replicationType = iff((remoteVolumeRegion == location), "CZR", iff((remoteVolumeRegion == ""),"n/a","CRR"))
+| where replicationType != "CZR" and volumeType != "DataProtection"
+| project recommendationId = "ANF-7", name, id, tags, replicationType


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Found a small typo changed "zone" -> "region".

Updated and tested KQL for ANF-6 and ANF-7. Previous KQL was showing positive results instead of negative results.

## Related Issues/Work Items

n/a

- To associate a GitHub Issue, use a [key word](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) preceded with the GitHub issue number.
- To associate an ADO Work Item, use the key word `AB#` succeeded with the [ADO Work Item ID](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

## This PR fixes/adds/changes/removes

1. one small typo to _index
2. anf-6.kql
3. anf-7.kql

### Breaking Changes

n/a

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
- [x] Ensured PR tests are passing
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries and/or scripts
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
