### PR TITLE
agw-9 - fixes recommendation id

### DIFF
--- a/docs/content/services/networking/application-gateway/code/agw-9/agw-9.kql
+++ b/docs/content/services/networking/application-gateway/code/agw-9/agw-9.kql
@@ -11,4 +11,4 @@ resources
     | extend addressprefix = tostring(properties_subnets.properties.addressPrefix)
     | project subnetid, addressprefix) on subnetid
 | where addressprefix !endswith '/24'
-| project recommendationID = "agw-8", name, id, tags, param1 = strcat('AppGW subnet prefix: ', addressprefix)
+| project recommendationID = "agw-9", name, id, tags, param1 = strcat('AppGW subnet prefix: ', addressprefix)


### PR DESCRIPTION
# Overview/Summary

Fixes the recommendation id in the query.

![image](https://github.com/Azure/Azure-Proactive-Resiliency-Library/assets/5988767/1100fa4c-a7d4-4178-8645-f4a6f337804b)

## Related Issues/Work Items

## This PR fixes/adds/changes/removes

### Breaking Changes

none

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries and/or scripts
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
