### PR TITLE
agw-7 check for AppGw deployed in multiple Zones

### DIFF
--- a/docs/content/services/networking/application-gateway/_index.md
+++ b/docs/content/services/networking/application-gateway/_index.md
@@ -20,6 +20,7 @@ The presented resiliency recommendations in this guidance include Application Ga
 | [AGW-4 - Use Application GW V2 instead of V1](#agw-4---use-application-gw-v2-instead-of-v1)                                                  | System Efficiency |  High  | Preview |         Yes         |
 | [AGW-5 - Monitor and Log the configurations and traffic](#agw-5---monitor-and-log-the-configurations-and-traffic)                            |    Monitoring     | Medium | Preview |         No          |
 | [AGW-6 - Use Health Probes to detect backend availability](#agw-6---use-health-probes-to-detect-backend-availability)                        |    Monitoring     | Medium | Preview |         Yes         |
+| [AGW-7 - Deploy Application Gateway in a zone-redundant configuration](#agw-7---deploy-application-gateway-in-a-zone-redundant-configuration)|   Availability    |  High  | Preview |         Yes         |
 | [AGW-8 - Plan for backend maintenance by using connection draining](#agw-8---plan-for-backend-maintenance-by-using-connection-draining)      |    Governance     | Medium | Preview |         No          |
 | [AGW-9 - Ensure Application Gateway Subnet is using a /24 subnet mask](#agw-9---ensure-application-gateway-subnet-is-using-a-24-subnet-mask) |    Networking     |  High  | Preview |         Yes          |
 
@@ -180,6 +181,31 @@ Using custom health probes can help with understand the availability of your bac
 {{< collapse title="Show/Hide Query/Script" >}}
 
 {{< code lang="sql" file="code/agw-6/agw-6.kql" >}} {{< /code >}}
+
+{{< /collapse >}}
+
+<br><br>
+
+### AGW-7 - Deploy Application Gateway in a zone-redundant configuration
+
+**Category: Availability**
+
+**Impact: High**
+
+**Guidance**
+
+Deploying your Application Gateway in a zone-aware configurations ensures that if a specific zone goes down that customers will still have access to the services as the other services located in other zones will still be available.
+
+**Resources**
+
+- [Well-Architected Framework Application Gateway Reliability](https://learn.microsoft.com/azure/well-architected/services/networking/azure-application-gateway#reliability)
+- [Application Gateway V2 Overview](https://learn.microsoft.com/azure/application-gateway/overview-v2)
+
+**Resource Graph Query**
+
+{{< collapse title="Show/Hide Query/Script" >}}
+
+{{< code lang="sql" file="code/agw-7/agw-7.kql" >}} {{< /code >}}
 
 {{< /collapse >}}
 

--- a/docs/content/services/networking/application-gateway/code/agw-7/agw-7.kql
+++ b/docs/content/services/networking/application-gateway/code/agw-7/agw-7.kql
@@ -1,1 +1,7 @@
-// under-development
+// Azure Resource Graph Query
+// list Application Gateways that are not configured to use at least 2 Availability Zones
+resources
+| where type =~ "microsoft.network/applicationGateways"
+| where isnull(zones) or array_length(zones) < 2
+| extend zoneValue = iff((isnull(zones)), "null", zones)
+| project recommendationId = "agw-7", name, id, tags, param1="Zones: No Zone or Zonal", param2=strcat("Zones value: ", zoneValue )

--- a/docs/content/services/networking/application-gateway/code/agw-7/agw-7.kql.fix
+++ b/docs/content/services/networking/application-gateway/code/agw-7/agw-7.kql.fix
@@ -1,8 +1,0 @@
-// Azure Resource Graph Query
-// You can use the following Azure Resource Graph Query to see if the Application Gateway is zone redundant
-Resources
-| where type =~ "microsoft.network/applicationGateways"
-| extend appGatewayResourceId = tostring(id)
-| extend zoneRedundant = tostring(properties.enableZoneRedundancy)
-| project appGatewayResourceId, zoneRedundant
-


### PR DESCRIPTION
# Overview/Summary

Creates agw-7 recommendation for zone-redundant Application Gateway deployment

![image](https://github.com/Azure/Azure-Proactive-Resiliency-Library/assets/5988767/69112fba-eee7-47af-8006-fd5518df20d1)

## Related Issues/Work Items

## This PR fixes/adds/changes/removes

1. add agw-7 recommendation with resource graph query

### Breaking Changes

none

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
- [x] Ensured PR tests are passing
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries and/or scripts
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
