### PR TITLE
corrected join failures due to case mismatch

### DIFF
--- a/docs/content/services/networking/expressroute-gateway/code/ergw-1/ergw-1.kql
+++ b/docs/content/services/networking/expressroute-gateway/code/ergw-1/ergw-1.kql
@@ -5,28 +5,28 @@
 (resources
 | where type == "microsoft.network/virtualnetworkgateways"
 | where properties.gatewayType == "ExpressRoute"
-| extend exrGatewayId = tostring(id)
+| extend exrGatewayId = tolower(tostring(id))
 | join kind=inner(
 resources
 | where type == "microsoft.network/virtualnetworkgateways"
 | where properties.gatewayType == "ExpressRoute"
-| extend exrGatewayId = tostring(id)
+| extend exrGatewayId = tolower(tostring(id))
 | join kind=leftouter(
 //connections joined with circuit peer info
 resources
 | where type == "microsoft.network/connections"
 | extend connectionType = properties.connectionType
-| extend exrGatewayId = tostring(properties.virtualNetworkGateway1.id)
-| extend peerId = tostring(properties.peer.id)
-| extend connectionId = tostring(id)
+| extend exrGatewayId = tolower(tostring(properties.virtualNetworkGateway1.id))
+| extend peerId = tolower(tostring(properties.peer.id))
+| extend connectionId = tolower(tostring(id))
 | where connectionType == "ExpressRoute"
 | join kind=leftouter(
   resources
   | where type == "microsoft.network/expressroutecircuits"
     //should this be location instead of peeringLocation
-  | extend circuitId = tostring(id)
+  | extend circuitId = tolower(tostring(id))
   | extend peeringLocation = tostring(properties.serviceProviderProperties.peeringLocation)
-  | extend peerId = id
+  | extend peerId = tolower(id)
 ) on peerId ) on exrGatewayId
 //remove bare metal services connections/circuits
 | where not(isnotnull(connectionId) and isnull(sku1))
@@ -41,15 +41,15 @@ resources
 resources
 | where type == "microsoft.network/virtualnetworkgateways"
 | where properties.gatewayType == "ExpressRoute"
-| extend exrGatewayId = tostring(id)
+| extend exrGatewayId = tolower(tostring(id))
 | join kind=leftouter(
 //connections joined with circuit peer info
 resources
 | where type == "microsoft.network/connections"
 | extend connectionType = properties.connectionType
-| extend exrGatewayId = tostring(properties.virtualNetworkGateway1.id)
-| extend peerId = tostring(properties.peer.id)
-| extend connectionId = tostring(id)
+| extend exrGatewayId = tolower(tostring(properties.virtualNetworkGateway1.id))
+| extend peerId = tolower(tostring(properties.peer.id))
+| extend connectionId = tolower(tostring(id))
 | where connectionType == "ExpressRoute") on exrGatewayId
 | where isnull(connectionType)
 | project recommendationId = "ergw-1", name, id, tags, param1 = "twoOrMoreCircuitsConnectedFromDifferentPeeringLocations: false", param2 = "noConnectionsOnGateway: true"

--- a/docs/content/services/networking/expressroute-gateway/code/ergw-4/ergw-4.1.kql
+++ b/docs/content/services/networking/expressroute-gateway/code/ergw-4/ergw-4.1.kql
@@ -4,7 +4,7 @@
 resources
 | where type == "microsoft.network/virtualnetworkgateways"
 | where properties.gatewayType == "ExpressRoute"
-| extend gatewayId = tostring(id)
+| extend gatewayId = tolower(tostring(id))
 | extend skuName = properties.sku.name
 | project gatewayId, name, id, tags, skuName
 | join kind=leftouter(
@@ -14,7 +14,7 @@ resources
 | mv-expand alertProperties.scopes
 | mv-expand alertProperties.criteria.allOf
 | where alertProperties.enabled == true
-| extend gatewayId = tostring(alertProperties_scopes)
+| extend gatewayId = tolower(tostring(alertProperties_scopes))
 | extend criterionType = alertProperties_criteria_allOf.criterionType
 | extend metric = alertProperties_criteria_allOf.metricName
 | extend metricNamespace = alertProperties_criteria_allOf.metricNamespace

--- a/docs/content/services/networking/expressroute-gateway/code/ergw-4/ergw-4.2.kql
+++ b/docs/content/services/networking/expressroute-gateway/code/ergw-4/ergw-4.2.kql
@@ -4,7 +4,7 @@
 resources
 | where type == "microsoft.network/virtualnetworkgateways"
 | where properties.gatewayType == "ExpressRoute"
-| extend gatewayId = tostring(id)
+| extend gatewayId = tolower(tostring(id))
 | extend skuName = properties.sku.name
 | extend routesLearnedPerSku = case(skuName == 'Standard', 4000,
                                     skuName == 'ErGw1AZ', 4000,
@@ -22,7 +22,7 @@ resources
 | mv-expand alertProperties.scopes
 | mv-expand alertProperties.criteria.allOf
 | where alertProperties.enabled == true
-| extend gatewayId = tostring(alertProperties_scopes)
+| extend gatewayId = tolower(tostring(alertProperties_scopes))
 | extend criterionType = alertProperties_criteria_allOf.criterionType
 | extend metric = alertProperties_criteria_allOf.metricName
 | extend metricNamespace = alertProperties_criteria_allOf.metricNamespace

--- a/docs/content/services/networking/expressroute-gateway/code/ergw-4/ergw-4.3.kql
+++ b/docs/content/services/networking/expressroute-gateway/code/ergw-4/ergw-4.3.kql
@@ -4,7 +4,7 @@
 resources
 | where type == "microsoft.network/virtualnetworkgateways"
 | where properties.gatewayType == "ExpressRoute"
-| extend gatewayId = tostring(id)
+| extend gatewayId = tolower(tostring(id))
 | extend skuName = properties.sku.name
 | project gatewayId, name, id, tags, skuName
 | join kind=leftouter(
@@ -14,7 +14,7 @@ resources
 | mv-expand alertProperties.scopes
 | mv-expand alertProperties.criteria.allOf
 | where alertProperties.enabled == true
-| extend gatewayId = tostring(alertProperties_scopes)
+| extend gatewayId = tolower(tostring(alertProperties_scopes))
 | extend criterionType = alertProperties_criteria_allOf.criterionType
 | extend metric = alertProperties_criteria_allOf.metricName
 | extend metricNamespace = alertProperties_criteria_allOf.metricNamespace

--- a/docs/content/services/networking/expressroute-gateway/code/ergw-4/ergw-4.4.kql
+++ b/docs/content/services/networking/expressroute-gateway/code/ergw-4/ergw-4.4.kql
@@ -4,7 +4,7 @@
 resources
 | where type == "microsoft.network/virtualnetworkgateways"
 | where properties.gatewayType == "ExpressRoute"
-| extend gatewayId = tostring(id)
+| extend gatewayId = tolower(tostring(id))
 | extend skuName = properties.sku.name
 | project gatewayId, name, id, tags, skuName
 | join kind=leftouter(
@@ -14,7 +14,7 @@ resources
 | mv-expand alertProperties.scopes
 | mv-expand alertProperties.criteria.allOf
 | where alertProperties.enabled == true
-| extend gatewayId = tostring(alertProperties_scopes)
+| extend gatewayId = tolower(tostring(alertProperties_scopes))
 | extend criterionType = alertProperties_criteria_allOf.criterionType
 | extend metric = alertProperties_criteria_allOf.metricName
 | extend metricNamespace = alertProperties_criteria_allOf.metricNamespace

--- a/docs/content/services/networking/expressroute-gateway/code/ergw-4/ergw-4.5.kql
+++ b/docs/content/services/networking/expressroute-gateway/code/ergw-4/ergw-4.5.kql
@@ -4,7 +4,7 @@
 resources
 | where type == "microsoft.network/virtualnetworkgateways"
 | where properties.gatewayType == "ExpressRoute"
-| extend gatewayId = tostring(id)
+| extend gatewayId = tolower(tostring(id))
 | extend skuName = properties.sku.name
 | extend packetsPerSecondSku = case(skuName == 'Standard', 100000,
                                     skuName == 'ErGw1AZ', 100000,
@@ -22,7 +22,7 @@ resources
 | mv-expand alertProperties.scopes
 | mv-expand alertProperties.criteria.allOf
 | where alertProperties.enabled == true
-| extend gatewayId = tostring(alertProperties_scopes)
+| extend gatewayId = tolower(tostring(alertProperties_scopes))
 | extend criterionType = alertProperties_criteria_allOf.criterionType
 | extend metric = alertProperties_criteria_allOf.metricName
 | extend metricNamespace = alertProperties_criteria_allOf.metricNamespace

--- a/docs/content/services/networking/expressroute-gateway/code/ergw-4/ergw-4.6.kql
+++ b/docs/content/services/networking/expressroute-gateway/code/ergw-4/ergw-4.6.kql
@@ -4,7 +4,7 @@
 resources
 | where type == "microsoft.network/virtualnetworkgateways"
 | where properties.gatewayType == "ExpressRoute"
-| extend gatewayId = tostring(id)
+| extend gatewayId = tolower(tostring(id))
 | extend skuName = properties.sku.name
 | extend flowsPerSku = case(skuName == 'Standard', 100000,
                                     skuName == 'ErGw1AZ', 100000,
@@ -22,7 +22,7 @@ resources
 | mv-expand alertProperties.scopes
 | mv-expand alertProperties.criteria.allOf
 | where alertProperties.enabled == true
-| extend gatewayId = tostring(alertProperties_scopes)
+| extend gatewayId = tolower(tostring(alertProperties_scopes))
 | extend criterionType = alertProperties_criteria_allOf.criterionType
 | extend metric = alertProperties_criteria_allOf.metricName
 | extend metricNamespace = alertProperties_criteria_allOf.metricNamespace

--- a/docs/content/services/networking/expressroute-gateway/code/ergw-4/ergw-4.7.kql
+++ b/docs/content/services/networking/expressroute-gateway/code/ergw-4/ergw-4.7.kql
@@ -4,7 +4,7 @@
 resources
 | where type == "microsoft.network/virtualnetworkgateways"
 | where properties.gatewayType == "ExpressRoute"
-| extend gatewayId = tostring(id)
+| extend gatewayId = tolower(tostring(id))
 | extend skuName = properties.sku.name
 | extend maxVMsPerSku = case(skuName == 'Standard', 2000,
                                     skuName == 'ErGw1AZ', 2000,
@@ -22,7 +22,7 @@ resources
 | mv-expand alertProperties.scopes
 | mv-expand alertProperties.criteria.allOf
 | where alertProperties.enabled == true
-| extend gatewayId = tostring(alertProperties_scopes)
+| extend gatewayId = tolower(tostring(alertProperties_scopes))
 | extend criterionType = alertProperties_criteria_allOf.criterionType
 | extend metric = alertProperties_criteria_allOf.metricName
 | extend metricNamespace = alertProperties_criteria_allOf.metricNamespace

--- a/docs/content/services/specialized-workloads/azure-vmware-solution/code/avs-1/avs-1.kql
+++ b/docs/content/services/specialized-workloads/azure-vmware-solution/code/avs-1/avs-1.kql
@@ -3,7 +3,8 @@
 //full list of private clouds
 (resources
 | where ['type'] == "microsoft.avs/privateclouds"
-| extend locale = location
+| extend locale = tolower(location)
+| extend subscriptionId = tolower(subscriptionId)
 | project id, name, tags, subscriptionId, locale)
 | join kind=leftouter
 //Alert ID's that include all incident types filtered by AVS Service Health alerts
@@ -20,6 +21,7 @@
 //Alert ID's that include only some of the incident types after filtering by service health alerts covering AVS private clouds.
 (resources
 | where type == "microsoft.insights/activitylogalerts"
+| extend subscriptionId = tolower(subscriptionId)
 | extend alertproperties = todynamic(properties)
 | where alertproperties.condition.allOf[0].field == "category" and alertproperties.condition.allOf[0].equals == "ServiceHealth"
 | where alertproperties.condition.allOf[2].field == "properties.impactedServices[*].ServiceName" and set_has_element(alertproperties.condition.allOf[2].containsAny, "Azure VMware Solution")

--- a/docs/content/services/specialized-workloads/azure-vmware-solution/code/avs-3/avs-3.kql
+++ b/docs/content/services/specialized-workloads/azure-vmware-solution/code/avs-3/avs-3.kql
@@ -3,7 +3,7 @@
 (
 resources
 | where ['type'] == "microsoft.avs/privateclouds"
-| extend scopeId = tostring(id)
+| extend scopeId = tolower(tostring(id))
 | project ['scopeId'], name, id, tags
 | join kind=leftouter (
 resources
@@ -11,7 +11,7 @@ resources
 | extend alertProperties = todynamic(properties)
 | mv-expand alertProperties.scopes
 | mv-expand alertProperties.criteria.allOf
-| extend scopeId = tostring(alertProperties_scopes)
+| extend scopeId = tolower(tostring(alertProperties_scopes))
 | extend metric = alertProperties_criteria_allOf.metricName
 | extend threshold = alertProperties_criteria_allOf.threshold
 | project scopeId, tostring(metric), toint(['threshold'])
@@ -24,7 +24,7 @@ resources
 | union (
 resources
 | where ['type'] == "microsoft.avs/privateclouds"
-| extend scopeId = tostring(id)
+| extend scopeId = tolower(tostring(id))
 | project ['scopeId'], name, id, tags
 | join kind=leftouter (
 resources
@@ -32,7 +32,7 @@ resources
 | extend alertProperties = todynamic(properties)
 | mv-expand alertProperties.scopes
 | mv-expand alertProperties.criteria.allOf
-| extend scopeId = tostring(alertProperties_scopes)
+| extend scopeId = tolower(tostring(alertProperties_scopes))
 | extend metric = alertProperties_criteria_allOf.metricName
 | extend threshold = alertProperties_criteria_allOf.threshold
 | project scopeId, tostring(metric), toint(['threshold'])

--- a/docs/content/services/specialized-workloads/azure-vmware-solution/code/avs-5/avs-5.kql
+++ b/docs/content/services/specialized-workloads/azure-vmware-solution/code/avs-5/avs-5.kql
@@ -2,7 +2,7 @@
 // Provides a list of Azure VMware Solution resources that don't have a Cluster CPU capacity critical alert with a threshold of 95%.
 resources
 | where ['type'] == "microsoft.avs/privateclouds"
-| extend scopeId = tostring(id)
+| extend scopeId = tolower(tostring(id))
 | project ['scopeId'], name, id, tags
 | join kind=leftouter (
 resources
@@ -10,7 +10,7 @@ resources
 | extend alertProperties = todynamic(properties)
 | mv-expand alertProperties.scopes
 | mv-expand alertProperties.criteria.allOf
-| extend scopeId = tostring(alertProperties_scopes)
+| extend scopeId = tolower(tostring(alertProperties_scopes))
 | extend metric = alertProperties_criteria_allOf.metricName
 | extend threshold = alertProperties_criteria_allOf.threshold
 | project scopeId, tostring(metric), toint(['threshold'])

--- a/docs/content/services/specialized-workloads/azure-vmware-solution/code/avs-6/avs-6.kql
+++ b/docs/content/services/specialized-workloads/azure-vmware-solution/code/avs-6/avs-6.kql
@@ -2,7 +2,7 @@
 // Provides a list of Azure VMware Solution resources that don't have a cluster host memory critical alert with a threshold of 95%.
 resources
 | where ['type'] == "microsoft.avs/privateclouds"
-| extend scopeId = tostring(id)
+| extend scopeId = tolower(tostring(id))
 | project ['scopeId'], name, id, tags
 | join kind=leftouter (
 resources
@@ -10,7 +10,7 @@ resources
 | extend alertProperties = todynamic(properties)
 | mv-expand alertProperties.scopes
 | mv-expand alertProperties.criteria.allOf
-| extend scopeId = tostring(alertProperties_scopes)
+| extend scopeId = tolower(tostring(alertProperties_scopes))
 | extend metric = alertProperties_criteria_allOf.metricName
 | extend threshold = alertProperties_criteria_allOf.threshold
 | project scopeId, tostring(metric), toint(['threshold'])


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

This pull request contains fixes for ERGW-1, ERGW-4, AVS-1, AVS-3, AVS-5, and AVS-6 ARG kusto queries.  It corrects an issue where certain id string used in kusto join statements had case mismatches causing incomplete or inaccurate results.  This PR updates the relevant kusto queries to force all fields used in a join statement to first be cast to lower case.

closes #425 

## Related Issues/Work Items

Replace this with a list of related GitHub Issues and/or ADO Work Items (Internal Only)
- AVS bug 34512 (ADO)
- #425 



## This PR fixes/adds/changes/removes

1. ERGW-1, ERGW-4, AVS-1, AVS-3, AVS-5, and AVS-6 ARG kusto queries.

### Breaking Changes

No Breaking Changes.

## As part of this Pull Request I have

- [ x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library/contributing) and ensured this PR is compliant with the guide
- [ x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library/pulls)
- [ x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library/issues) or ADO Work Items (Internal Only)
- [ x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library/tree/main)
- [ x] Ensured PR tests are passing
- [ x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries and/or scripts
- [ x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
